### PR TITLE
Improve Windows compatibility

### DIFF
--- a/claudechic/__main__.py
+++ b/claudechic/__main__.py
@@ -62,7 +62,7 @@ def main():
         import traceback
 
         crash_log = Path(tempfile.gettempdir()) / "claudechic-crash.log"
-        with open(crash_log, "w") as f:
+        with open(crash_log, "w", encoding="utf-8") as f:
             traceback.print_exc(file=f)
         raise
 

--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -256,14 +256,6 @@ def _handle_shell(app: "ChatApp", command: str) -> bool:
     """
     import sys
 
-    # Windows doesn't have PTY support for captured output
-    if sys.platform == "win32":
-        app.notify(
-            "Shell command not fully supported on Windows. Use Claude's Bash tool.",
-            severity="warning",
-        )
-        return True
-
     parts = command.split(maxsplit=1)
     cmd = parts[1] if len(parts) > 1 else None
 
@@ -273,33 +265,63 @@ def _handle_shell(app: "ChatApp", command: str) -> bool:
         interactive = True
         cmd = cmd[3:].lstrip()
 
+    # Windows doesn't have PTY support for captured output - force interactive mode
+    is_windows = sys.platform == "win32"
+    if is_windows and cmd and not interactive:
+        app.notify(
+            "Captured shell output not supported on Windows. Running interactively.",
+            severity="warning",
+        )
+        interactive = True
+
     agent = app._agent
     cwd = str(agent.cwd) if agent else None
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-    # Force color output, disable pagers for captured output
-    env.update(
-        {
-            "FORCE_COLOR": "1",
-            "CLICOLOR_FORCE": "1",
-            "TERM": "xterm-256color",
-            "BAT_PAGER": "",
-            "PAGER": "",
-        }
-    )
-    shell = os.environ.get("SHELL", "/bin/sh")
+
+    # Platform-specific shell and args
+    if is_windows:
+        # Windows: use cmd.exe or PowerShell
+        shell = os.environ.get("COMSPEC", "cmd.exe")
+        if cmd:
+            args = [shell, "/c", cmd]
+        else:
+            args = [shell]
+    else:
+        # Unix: use SHELL env var or fallback to /bin/sh
+        # Force color output, disable pagers for captured output
+        env.update(
+            {
+                "FORCE_COLOR": "1",
+                "CLICOLOR_FORCE": "1",
+                "TERM": "xterm-256color",
+                "BAT_PAGER": "",
+                "PAGER": "",
+            }
+        )
+        shell = os.environ.get("SHELL", "/bin/sh")
+        if cmd:
+            args = [shell, "-lc", cmd] if not interactive else [shell, "-c", cmd]
+        else:
+            args = [shell, "-l"]
 
     if cmd and not interactive:
-        # Async execution with captured output
+        # Async execution with captured output (Unix only)
         app.run_shell_command(cmd, shell, cwd, env)
     else:
         # Interactive: suspend TUI and run in real terminal
-        with app.suspend():
-            args = [shell, "-lc", cmd] if cmd else [shell, "-l"]
-            start = time.monotonic()
-            subprocess.run(args, cwd=cwd, env=env)
-            # If command was fast, wait for keypress so user can see output
-            if cmd and time.monotonic() - start < 1.0:
-                _wait_for_keypress()
+        try:
+            with app.suspend():
+                start = time.monotonic()
+                subprocess.run(args, cwd=cwd, env=env)
+                # If command was fast, wait for keypress so user can see output
+                if cmd and time.monotonic() - start < 1.0:
+                    _wait_for_keypress()
+        except Exception as e:
+            # SuspendNotSupported or other errors (e.g., in test environments)
+            app.notify(
+                f"Shell suspend not supported in this environment: {e}",
+                severity="error",
+            )
 
     return True
 

--- a/claudechic/compact.py
+++ b/claudechic/compact.py
@@ -84,7 +84,7 @@ def compact_session(
 
     # Load all messages
     messages = []
-    with open(session_file) as f:
+    with open(session_file, encoding="utf-8") as f:
         for line in f:
             if line.strip():
                 messages.append(json.loads(line))
@@ -334,7 +334,7 @@ def compact_session(
     backup_file = session_file.with_suffix(".jsonl.bak")
     shutil.copy(session_file, backup_file)
 
-    with open(session_file, "w") as f:
+    with open(session_file, "w", encoding="utf-8") as f:
         for m in compacted_messages:
             f.write(json.dumps(m) + "\n")
 

--- a/claudechic/config.py
+++ b/claudechic/config.py
@@ -19,7 +19,7 @@ def _load_config() -> dict:
         return _config
 
     if CONFIG_PATH.exists():
-        with open(CONFIG_PATH) as f:
+        with open(CONFIG_PATH, encoding="utf-8") as f:
             _config = yaml.safe_load(f) or {}
         is_new_file = False
     else:
@@ -49,7 +49,7 @@ def _save_config() -> None:
     if not _config:
         return
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(CONFIG_PATH, "w") as f:
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
         yaml.dump(_config, f, default_flow_style=False)
 
 

--- a/claudechic/history.py
+++ b/claudechic/history.py
@@ -19,7 +19,7 @@ def append_to_history(display: str, project: Path, session_id: str) -> None:
         "sessionId": session_id,
     }
     try:
-        with open(HISTORY_FILE, "a") as f:
+        with open(HISTORY_FILE, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")
     except OSError:
         pass  # Silently fail if can't write
@@ -35,7 +35,7 @@ def load_global_history(limit: int = 1000) -> list[str]:
 
     entries: list[tuple[int, str]] = []  # (timestamp, display)
     try:
-        with open(HISTORY_FILE) as f:
+        with open(HISTORY_FILE, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:


### PR DESCRIPTION
- Shell commands: Use cmd.exe on Windows, force interactive mode since PTY capture isn't supported. Handle SuspendNotSupported gracefully.
- Path completion: Support Windows path separators and drive letters, detect executables via PATHEXT instead of execute bit.
- File encoding: Add explicit UTF-8 encoding to all file operations to avoid Windows default encoding issues.