### PR TITLE
Add vi-mode for input editing

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -536,6 +536,12 @@ class ChatApp(App):
         # Focus input immediately - UI is ready
         self.chat_input.focus()
 
+        # Initialize vi-mode if enabled in config
+        from claudechic.config import get_vi_mode
+
+        if get_vi_mode():
+            self._update_vi_mode(True)
+
         # Connect SDK in background - UI renders while this happens
         self._connect_initial_client()
 
@@ -668,6 +674,13 @@ class ChatApp(App):
             return
         self.chat_input.clear()
         self._handle_prompt(event.text)
+
+    def on_chat_input_vi_mode_changed(self, event: ChatInput.ViModeChanged) -> None:
+        """Update footer when vi-mode changes."""
+        from claudechic.config import get_vi_mode
+
+        enabled = get_vi_mode()
+        self.status_footer.update_vi_mode(event.mode if enabled else None, enabled)
 
     def _handle_prompt(self, prompt: str) -> None:
         """Process a prompt - handles local commands or sends to Claude."""
@@ -1977,3 +1990,14 @@ class ChatApp(App):
             self.chat_input.focus()
 
         self.push_screen(DiffScreen(agent.cwd), on_dismiss)
+
+    def _update_vi_mode(self, enabled: bool) -> None:
+        """Update vi-mode on all ChatInput widgets and footer."""
+        try:
+            chat_input = self.query_one("#chat-input", ChatInput)
+            chat_input.enable_vi_mode(enabled)
+            # Update footer with initial mode
+            mode = chat_input.vi_mode if enabled else None
+            self.status_footer.update_vi_mode(mode, enabled)
+        except Exception:
+            pass

--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -35,6 +35,7 @@ COMMANDS: list[tuple[str, str, list[str]]] = [
     ("/compactish", "Compact session to reduce context", []),
     ("/usage", "Show API rate limit usage", []),
     ("/model", "Change model", []),
+    ("/vim", "Toggle vi mode for input", []),
     ("/processes", "Show background processes", []),
     (
         "/analytics",
@@ -138,6 +139,9 @@ def handle_command(app: "ChatApp", prompt: str) -> bool:
     if cmd == "/exit":
         app.exit()
         return True
+
+    if cmd == "/vim":
+        return _handle_vim(app)
 
     if cmd == "/welcome":
         return _handle_welcome(app)
@@ -472,6 +476,22 @@ def _handle_processes(app: "ChatApp") -> None:
     else:
         processes = []
     app.push_screen(ProcessModal(processes))
+
+
+def _handle_vim(app: "ChatApp") -> bool:
+    """Toggle vi-mode for input."""
+    from claudechic.config import get_vi_mode, set_vi_mode
+
+    current = get_vi_mode()
+    new_state = not current
+    set_vi_mode(new_state)
+
+    # Update all ChatInput widgets
+    app._update_vi_mode(new_state)
+
+    status = "enabled" if new_state else "disabled"
+    app.notify(f"Vi mode {status}")
+    return True
 
 
 def _handle_analytics(app: "ChatApp", command: str) -> bool:

--- a/claudechic/config.py
+++ b/claudechic/config.py
@@ -84,3 +84,17 @@ def is_new_install() -> bool:
     """Check if this is a new install (analytics ID was just created)."""
     _load_config()  # Ensure config is loaded
     return _new_install
+
+
+def get_vi_mode() -> bool:
+    """Check if vi mode is enabled."""
+    return _load_config().get("editor", {}).get("vi_mode", False)
+
+
+def set_vi_mode(enabled: bool) -> None:
+    """Enable or disable vi mode."""
+    config = _load_config()
+    if "editor" not in config:
+        config["editor"] = {}
+    config["editor"]["vi_mode"] = enabled
+    _save_config()

--- a/claudechic/help_data.py
+++ b/claudechic/help_data.py
@@ -23,13 +23,33 @@ SHORTCUTS = [
     ("Ctrl+L", "Clear chat"),
     ("Ctrl+S", "Screenshot"),
     ("Shift+Tab", "Toggle auto-edit mode"),
-    ("Escape", "Cancel current action"),
+    ("Escape", "Cancel / Enter NORMAL mode (vi)"),
     ("Ctrl+N", "New agent hint"),
-    ("Ctrl+R", "History search"),
+    ("Ctrl+R", "History search / Redo (vi)"),
     ("Ctrl+1-9", "Switch to agent by position"),
     ("Enter", "Send message"),
     ("Ctrl+J", "Insert newline"),
     ("Up/Down", "Navigate input history"),
+]
+
+# Vi mode keybindings (shown when vi mode is enabled)
+VI_MODE_KEYS = [
+    ("Esc", "Enter NORMAL mode"),
+    ("i / I", "Insert before cursor / at line start"),
+    ("a / A", "Insert after cursor / at line end"),
+    ("o / O", "Open line below / above"),
+    ("h / j / k / l", "Move left / down / up / right"),
+    ("w / b / e", "Move word forward / back / end"),
+    ("0 / $", "Move to line start / end"),
+    ("gg / G", "Go to input start / end"),
+    ("x", "Delete character"),
+    ("dd / D", "Delete line / to end of line"),
+    ("cc / C / cw", "Change line / to end / word"),
+    ("yy / yw", "Yank (copy) line / word"),
+    ("p / P", "Paste after / before cursor"),
+    ("u / Ctrl+R", "Undo / Redo"),
+    (".", "Repeat last change"),
+    ("v", "Enter VISUAL mode"),
 ]
 
 # MCP tools from claudechic (mcp.py)
@@ -186,6 +206,14 @@ async def format_help(agent: "Agent | None") -> str:
     lines.append("| Key | Action |")
     lines.append("|-----|--------|")
     for key, action in SHORTCUTS:
+        lines.append(f"| `{key}` | {action} |")
+    lines.append("")
+
+    # Vi mode
+    lines.append("## Vi Mode (toggle with `/vim`)\n")
+    lines.append("| Key | Action |")
+    lines.append("|-----|--------|")
+    for key, action in VI_MODE_KEYS:
         lines.append(f"| `{key}` | {action} |")
 
     return "\n".join(lines)

--- a/claudechic/styles.tcss
+++ b/claudechic/styles.tcss
@@ -103,6 +103,28 @@ ModelLabel:hover {
     color: $primary;
 }
 
+/* Vi mode indicator */
+#vi-mode-label {
+    width: auto;
+    padding: 0 1;
+    text-style: bold;
+}
+
+#vi-mode-label.vi-insert {
+    background: #005f00;
+    color: #afd7af;
+}
+
+#vi-mode-label.vi-normal {
+    background: #005f5f;
+    color: #afd7ff;
+}
+
+#vi-mode-label.vi-visual {
+    background: #5f005f;
+    color: #ffafd7;
+}
+
 /* Shared block styling - all content blocks */
 ChatMessage, BaseToolWidget, ThinkingIndicator, ErrorMessage, SystemInfo, #input-container {
     background: transparent;

--- a/claudechic/widgets/input/vi_mode.py
+++ b/claudechic/widgets/input/vi_mode.py
@@ -1,0 +1,624 @@
+"""Vi-mode state machine and key handling for text input."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from textual.widgets import TextArea
+
+
+class ViMode(Enum):
+    """Vi editor modes."""
+
+    INSERT = auto()
+    NORMAL = auto()
+    VISUAL = auto()
+
+
+@dataclass
+class ViState:
+    """State for vi-mode key handling."""
+
+    mode: ViMode = ViMode.INSERT
+    pending_operator: str | None = None  # 'd', 'c', 'y'
+    pending_count: str = ""  # Accumulated count digits (e.g., "12" for 12j)
+    pending_motion: str | None = None  # 'f', 't', 'F', 'T' waiting for char
+    pending_g: bool = False  # Waiting for second char after 'g'
+    last_change: tuple[str, ...] | None = None  # For '.' repeat
+    yank_buffer: str = ""  # Yanked text for p/P
+
+    def reset_pending(self) -> None:
+        """Clear pending state after command execution."""
+        self.pending_operator = None
+        self.pending_count = ""
+        self.pending_motion = None
+        self.pending_g = False
+
+    def get_count(self) -> int:
+        """Get pending count as int, defaulting to 1."""
+        return int(self.pending_count) if self.pending_count else 1
+
+
+class ViHandler:
+    """Handles vi-mode key processing for a TextArea widget."""
+
+    def __init__(self, text_area: TextArea) -> None:
+        self.text_area = text_area
+        self.state = ViState()
+        self._mode_changed_callback: Callable[[ViMode], None] | None = None
+
+    def set_mode_changed_callback(self, callback: Callable[[ViMode], None]) -> None:
+        """Set callback to be called when mode changes."""
+        self._mode_changed_callback = callback
+
+    def _notify_mode_change(self) -> None:
+        """Notify callback of mode change."""
+        if self._mode_changed_callback:
+            self._mode_changed_callback(self.state.mode)
+
+    def _set_mode(self, mode: ViMode) -> None:
+        """Set mode and notify."""
+        if self.state.mode != mode:
+            self.state.mode = mode
+            self._notify_mode_change()
+
+    def _set_selection(self, start: tuple[int, int], end: tuple[int, int]) -> None:
+        """Set text area selection using Selection class."""
+        from textual.widgets.text_area import Selection
+
+        self.text_area.selection = Selection(start, end)
+
+    def handle_key(self, key: str, character: str | None) -> bool:
+        """Handle a key press in vi-mode.
+
+        Returns True if the key was consumed, False if it should be handled normally.
+        """
+        mode = self.state.mode
+
+        # INSERT mode - only intercept Escape
+        if mode == ViMode.INSERT:
+            if key == "escape":
+                self._set_mode(ViMode.NORMAL)
+                self.state.reset_pending()
+                # Move cursor back one position (vim behavior)
+                row, col = self.text_area.cursor_location
+                if col > 0:
+                    self.text_area.move_cursor((row, col - 1))
+                return True
+            return False
+
+        # VISUAL mode
+        if mode == ViMode.VISUAL:
+            if key == "escape":
+                self._set_mode(ViMode.NORMAL)
+                loc = self.text_area.cursor_location
+                self._set_selection(loc, loc)
+                self.state.reset_pending()
+                return True
+            # Handle visual mode motions (extend selection)
+            return self._handle_visual_key(key, character)
+
+        # NORMAL mode
+        return self._handle_normal_key(key, character)
+
+    def _handle_normal_key(self, key: str, character: str | None) -> bool:
+        """Handle keys in NORMAL mode."""
+        state = self.state
+        ta = self.text_area
+
+        # Handle pending 'g' commands
+        if state.pending_g:
+            state.pending_g = False
+            if character == "g":
+                # gg - go to start
+                ta.move_cursor((0, 0))
+                state.reset_pending()
+                return True
+            state.reset_pending()
+            return True
+
+        # Handle pending character motion (f/F/t/T)
+        if state.pending_motion:
+            motion = state.pending_motion
+            state.pending_motion = None
+            if character:
+                self._execute_char_motion(motion, character)
+            state.reset_pending()
+            return True
+
+        # Accumulate count digits
+        if (
+            character
+            and character.isdigit()
+            and (state.pending_count or character != "0")
+        ):
+            state.pending_count += character
+            return True
+
+        # Mode switching
+        if character == "i":
+            self._set_mode(ViMode.INSERT)
+            state.reset_pending()
+            return True
+        if character == "I":
+            ta.action_cursor_line_start()
+            self._set_mode(ViMode.INSERT)
+            state.reset_pending()
+            return True
+        if character == "a":
+            # Move cursor right before entering insert mode
+            row, col = ta.cursor_location
+            line = ta.document.get_line(row)
+            if col < len(line):
+                ta.move_cursor((row, col + 1))
+            self._set_mode(ViMode.INSERT)
+            state.reset_pending()
+            return True
+        if character == "A":
+            ta.action_cursor_line_end()
+            self._set_mode(ViMode.INSERT)
+            state.reset_pending()
+            return True
+        if character == "o":
+            ta.action_cursor_line_end()
+            ta.insert("\n")
+            self._set_mode(ViMode.INSERT)
+            state.reset_pending()
+            return True
+        if character == "O":
+            ta.action_cursor_line_start()
+            ta.insert("\n")
+            ta.action_cursor_up()
+            self._set_mode(ViMode.INSERT)
+            state.reset_pending()
+            return True
+        if character == "v":
+            self._set_mode(ViMode.VISUAL)
+            # Start selection at current position
+            loc = ta.cursor_location
+            self._set_selection(loc, loc)
+            state.reset_pending()
+            return True
+
+        # Navigation
+        if character == "h" or key == "left":
+            for _ in range(state.get_count()):
+                ta.action_cursor_left()
+            state.reset_pending()
+            return True
+        if character == "l" or key == "right":
+            for _ in range(state.get_count()):
+                ta.action_cursor_right()
+            state.reset_pending()
+            return True
+        if character == "j" or key == "down":
+            for _ in range(state.get_count()):
+                ta.action_cursor_down()
+            state.reset_pending()
+            return True
+        if character == "k" or key == "up":
+            for _ in range(state.get_count()):
+                ta.action_cursor_up()
+            state.reset_pending()
+            return True
+        if character == "w":
+            for _ in range(state.get_count()):
+                ta.action_cursor_word_right()
+            state.reset_pending()
+            return True
+        if character == "b":
+            for _ in range(state.get_count()):
+                ta.action_cursor_word_left()
+            state.reset_pending()
+            return True
+        if character == "e":
+            # Move to end of word
+            for _ in range(state.get_count()):
+                self._move_to_word_end()
+            state.reset_pending()
+            return True
+        if character == "0":
+            ta.action_cursor_line_start()
+            state.reset_pending()
+            return True
+        if character == "$":
+            ta.action_cursor_line_end()
+            state.reset_pending()
+            return True
+        if character == "^":
+            # First non-whitespace character
+            ta.action_cursor_line_start()
+            row, _ = ta.cursor_location
+            line = ta.document.get_line(row)
+            for i, ch in enumerate(line):
+                if not ch.isspace():
+                    ta.move_cursor((row, i))
+                    break
+            state.reset_pending()
+            return True
+        if character == "g":
+            state.pending_g = True
+            return True
+        if character == "G":
+            ta.move_cursor(ta.document.end)
+            state.reset_pending()
+            return True
+
+        # Character motions
+        if character is not None and character in "fFtT":
+            state.pending_motion = character
+            return True
+
+        # Operators (d, c, y)
+        if character is not None and character in "dcy":
+            if state.pending_operator == character:
+                # Double operator (dd, cc, yy) - operate on line
+                self._execute_line_operator(character)
+                state.reset_pending()
+                return True
+            state.pending_operator = character
+            return True
+
+        # Immediate operators with pending operator
+        if state.pending_operator:
+            op = state.pending_operator
+            if character == "w":
+                self._execute_operator_motion(op, "word_right")
+                state.reset_pending()
+                return True
+            if character == "b":
+                self._execute_operator_motion(op, "word_left")
+                state.reset_pending()
+                return True
+            if character == "$":
+                self._execute_operator_motion(op, "line_end")
+                state.reset_pending()
+                return True
+            if character == "0":
+                self._execute_operator_motion(op, "line_start")
+                state.reset_pending()
+                return True
+            # Unknown motion - cancel
+            state.reset_pending()
+            return True
+
+        # Standalone editing commands
+        if character == "x":
+            # Delete character under cursor
+            for _ in range(state.get_count()):
+                ta.action_delete_right()
+            state.last_change = ("x",)
+            state.reset_pending()
+            return True
+        if character == "X":
+            # Delete character before cursor (backspace)
+            for _ in range(state.get_count()):
+                ta.action_delete_left()
+            state.last_change = ("X",)
+            state.reset_pending()
+            return True
+        if character == "D":
+            # Delete to end of line
+            ta.action_delete_to_end_of_line()
+            state.last_change = ("D",)
+            state.reset_pending()
+            return True
+        if character == "C":
+            # Change to end of line
+            ta.action_delete_to_end_of_line()
+            self._set_mode(ViMode.INSERT)
+            state.last_change = ("C",)
+            state.reset_pending()
+            return True
+        if character == "s":
+            # Substitute character (delete and insert)
+            ta.action_delete_right()
+            self._set_mode(ViMode.INSERT)
+            state.last_change = ("s",)
+            state.reset_pending()
+            return True
+        if character == "S":
+            # Substitute line (clear and insert)
+            ta.action_cursor_line_start()
+            ta.action_delete_line()
+            self._set_mode(ViMode.INSERT)
+            state.last_change = ("S",)
+            state.reset_pending()
+            return True
+
+        # Paste
+        if character == "p":
+            if state.yank_buffer:
+                row, col = ta.cursor_location
+                line = ta.document.get_line(row)
+                # Paste after cursor
+                new_col = min(col + 1, len(line))
+                ta.move_cursor((row, new_col))
+                ta.insert(state.yank_buffer)
+            state.reset_pending()
+            return True
+        if character == "P":
+            if state.yank_buffer:
+                ta.insert(state.yank_buffer)
+            state.reset_pending()
+            return True
+
+        # Undo/redo
+        if character == "u":
+            ta.action_undo()
+            state.reset_pending()
+            return True
+        if key == "ctrl+r":
+            ta.action_redo()
+            state.reset_pending()
+            return True
+
+        # Repeat last change
+        if character == ".":
+            if state.last_change:
+                self._replay_change(state.last_change)
+            state.reset_pending()
+            return True
+
+        # Join lines
+        if character == "J":
+            row, _ = ta.cursor_location
+            lines = ta.text.split("\n")
+            if row < len(lines) - 1:
+                # Move to end of current line, delete newline, insert space
+                ta.action_cursor_line_end()
+                ta.action_delete_right()  # Delete the newline
+                # Add space if next line doesn't start with one
+                ta.insert(" ")
+            state.reset_pending()
+            return True
+
+        # Replace single character
+        if character == "r":
+            # Wait for next character to replace with
+            state.pending_motion = "r"  # Reuse pending_motion for this
+            return True
+
+        state.reset_pending()
+        return True
+
+    def _handle_visual_key(self, key: str, character: str | None) -> bool:
+        """Handle keys in VISUAL mode (extend selection)."""
+        ta = self.text_area
+        state = self.state
+
+        # Get current selection start
+        start = ta.selection.start
+
+        # Navigation extends selection
+        if character == "h" or key == "left":
+            ta.action_cursor_left()
+            self._set_selection(start, ta.cursor_location)
+            return True
+        if character == "l" or key == "right":
+            ta.action_cursor_right()
+            self._set_selection(start, ta.cursor_location)
+            return True
+        if character == "j" or key == "down":
+            ta.action_cursor_down()
+            self._set_selection(start, ta.cursor_location)
+            return True
+        if character == "k" or key == "up":
+            ta.action_cursor_up()
+            self._set_selection(start, ta.cursor_location)
+            return True
+        if character == "w":
+            ta.action_cursor_word_right()
+            self._set_selection(start, ta.cursor_location)
+            return True
+        if character == "b":
+            ta.action_cursor_word_left()
+            self._set_selection(start, ta.cursor_location)
+            return True
+        if character == "$":
+            ta.action_cursor_line_end()
+            self._set_selection(start, ta.cursor_location)
+            return True
+        if character == "0":
+            ta.action_cursor_line_start()
+            self._set_selection(start, ta.cursor_location)
+            return True
+
+        # Get end for operations
+        end = ta.selection.end
+
+        # Operators on selection
+        if character == "d" or character == "x":
+            # Delete selection
+            selected = ta.selected_text
+            state.yank_buffer = selected
+            ta.delete(start, end)
+            self._set_mode(ViMode.NORMAL)
+            state.reset_pending()
+            return True
+        if character == "c":
+            # Change selection
+            selected = ta.selected_text
+            state.yank_buffer = selected
+            ta.delete(start, end)
+            self._set_mode(ViMode.INSERT)
+            state.reset_pending()
+            return True
+        if character == "y":
+            # Yank selection
+            state.yank_buffer = ta.selected_text
+            self._set_selection(start, start)  # Clear selection
+            ta.move_cursor(start)
+            self._set_mode(ViMode.NORMAL)
+            state.reset_pending()
+            return True
+
+        return True
+
+    def _move_to_word_end(self) -> None:
+        """Move cursor to end of current/next word."""
+        ta = self.text_area
+        text = ta.text
+        row, col = ta.cursor_location
+
+        # Convert to linear position
+        lines = text.split("\n")
+        pos = sum(len(lines[i]) + 1 for i in range(row)) + col
+
+        # Skip current word if on non-whitespace
+        while pos < len(text) and not text[pos].isspace():
+            pos += 1
+        # Skip whitespace
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        # Move to end of word
+        while pos < len(text) and not text[pos].isspace():
+            pos += 1
+        # Back up one to be at last char of word
+        if pos > 0:
+            pos -= 1
+
+        # Convert back to row, col
+        lines = text[:pos].split("\n")
+        new_row = len(lines) - 1
+        new_col = len(lines[-1]) if lines else 0
+        ta.move_cursor((new_row, new_col))
+
+    def _execute_char_motion(self, motion: str, char: str) -> None:
+        """Execute f/F/t/T motion to character."""
+        ta = self.text_area
+
+        # Handle 'r' for replace
+        if motion == "r":
+            ta.action_delete_right()
+            ta.insert(char)
+            # Move cursor back (replace doesn't advance)
+            row, col = ta.cursor_location
+            if col > 0:
+                ta.move_cursor((row, col - 1))
+            return
+
+        row, col = ta.cursor_location
+        line = ta.document.get_line(row)
+
+        if motion in "ft":
+            # Search forward
+            idx = line.find(char, col + 1)
+            if idx >= 0:
+                target = idx if motion == "f" else idx - 1
+                ta.move_cursor((row, max(col, target)))
+        else:
+            # Search backward
+            idx = line.rfind(char, 0, col)
+            if idx >= 0:
+                target = idx if motion == "F" else idx + 1
+                ta.move_cursor((row, min(col, target)))
+
+    def _execute_line_operator(self, op: str) -> None:
+        """Execute line operator (dd, cc, yy)."""
+        ta = self.text_area
+        state = self.state
+        row, _ = ta.cursor_location
+
+        # Select the entire line
+        ta.action_cursor_line_start()
+        line_start = ta.cursor_location
+        ta.action_cursor_line_end()
+
+        # Include newline if not last line
+        lines = ta.text.split("\n")
+        if row < len(lines) - 1:
+            ta.action_cursor_right()  # Include \n
+
+        line_end = ta.cursor_location
+
+        if op == "y":
+            # Yank line
+            self._set_selection(line_start, line_end)
+            state.yank_buffer = ta.selected_text
+            self._set_selection(line_start, line_start)
+            ta.move_cursor(line_start)
+        elif op == "d":
+            # Delete line
+            self._set_selection(line_start, line_end)
+            state.yank_buffer = ta.selected_text
+            ta.delete(line_start, line_end)
+            state.last_change = ("dd",)
+        elif op == "c":
+            # Change line (delete and enter insert mode)
+            self._set_selection(line_start, line_end)
+            state.yank_buffer = ta.selected_text
+            ta.delete(line_start, line_end)
+            self._set_mode(ViMode.INSERT)
+            state.last_change = ("cc",)
+
+    def _execute_operator_motion(self, op: str, motion: str) -> None:
+        """Execute operator with motion (dw, cw, y$, etc.)."""
+        ta = self.text_area
+        state = self.state
+        start = ta.cursor_location
+
+        # Execute motion
+        if motion == "word_right":
+            ta.action_cursor_word_right()
+        elif motion == "word_left":
+            ta.action_cursor_word_left()
+        elif motion == "line_end":
+            ta.action_cursor_line_end()
+        elif motion == "line_start":
+            ta.action_cursor_line_start()
+
+        end = ta.cursor_location
+
+        # Ensure start < end
+        if start > end:
+            start, end = end, start
+
+        if op == "y":
+            self._set_selection(start, end)
+            state.yank_buffer = ta.selected_text
+            self._set_selection(start, start)
+            ta.move_cursor(start)
+        elif op == "d":
+            self._set_selection(start, end)
+            state.yank_buffer = ta.selected_text
+            ta.delete(start, end)
+            state.last_change = ("d", motion)
+        elif op == "c":
+            self._set_selection(start, end)
+            state.yank_buffer = ta.selected_text
+            ta.delete(start, end)
+            self._set_mode(ViMode.INSERT)
+            state.last_change = ("c", motion)
+
+    def _replay_change(self, change: tuple[str, ...]) -> None:
+        """Replay a recorded change."""
+        ta = self.text_area
+
+        if change == ("x",):
+            ta.action_delete_right()
+        elif change == ("X",):
+            ta.action_delete_left()
+        elif change == ("D",):
+            ta.action_delete_to_end_of_line()
+        elif change == ("C",):
+            ta.action_delete_to_end_of_line()
+            self._set_mode(ViMode.INSERT)
+        elif change == ("s",):
+            ta.action_delete_right()
+            self._set_mode(ViMode.INSERT)
+        elif change == ("S",):
+            ta.action_cursor_line_start()
+            ta.action_delete_line()
+            self._set_mode(ViMode.INSERT)
+        elif change == ("dd",):
+            self._execute_line_operator("d")
+        elif change == ("cc",):
+            self._execute_line_operator("c")
+        elif len(change) == 2 and change[0] == "d":
+            self._execute_operator_motion("d", change[1])
+        elif len(change) == 2 and change[0] == "c":
+            self._execute_operator_motion("c", change[1])


### PR DESCRIPTION
Closes #7.

## Summary
- Add vim-style keybindings for chat input, toggle with `/vim` command
- Supports INSERT, NORMAL, VISUAL modes with navigation, operators, and editing commands
- Mode indicator in footer, persistent setting in config

## Test plan
- [x] Run `/vim` to enable vi-mode
- [x] Verify mode indicator shows "INSERT" in footer
- [x] Press Esc → indicator shows "NORMAL"
- [x] Test navigation: h/j/k/l, w/b, 0/$
- [x] Test operators: dd, cw, yy, p
- [x] Test mode switching: i, a, A, o, O
- [x] Verify `/vim` toggles off
- [x] All 74 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)