### PR TITLE
Fix session path encoding to match Claude Code

### DIFF
--- a/claudechic/sessions.py
+++ b/claudechic/sessions.py
@@ -65,7 +65,7 @@ def get_project_sessions_dir(cwd: Path | None = None) -> Path | None:
     cwd = (cwd or Path.cwd()).absolute()
     # Replace path separators with dashes (handles both / and \ on Windows)
     # Also remove Windows drive colon (C:\foo -> C-foo)
-    project_key = str(cwd).replace(os.sep, "-").replace(":", "")
+    project_key = str(cwd).replace(os.sep, "-").replace(":", "").replace(".", "-")
     sessions_dir = Path.home() / ".claude/projects" / project_key
     return sessions_dir if sessions_dir.exists() else None
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,23 @@
+"""Tests for session management."""
+
+import os
+from pathlib import Path
+
+
+def test_project_key_encoding():
+    """Verify project key matches Claude Code's encoding (dots become dashes)."""
+    # Simulate the encoding logic from sessions.py:get_project_sessions_dir
+    def encode_project_key(path: Path) -> str:
+        return str(path).replace(os.sep, "-").replace(":", "").replace(".", "-")
+
+    # Path with dot (like .local) should have dot replaced with dash
+    path = Path("/home/user/.local/share/chezmoi")
+    assert encode_project_key(path) == "-home-user--local-share-chezmoi"
+
+    # Regular path without dots
+    path = Path("/home/user/Code/project")
+    assert encode_project_key(path) == "-home-user-Code-project"
+
+    # Path with multiple dots
+    path = Path("/home/user/.config/.hidden")
+    assert encode_project_key(path) == "-home-user--config--hidden"


### PR DESCRIPTION
Claude Code replaces `.` with `-` when encoding project paths for session directories (e.g., `~/.local` becomes `--local`). This fix adds the same encoding so /resume can find sessions in directories containing dots.