### PR TITLE
Support agentic-sso proxy environment variables

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -541,9 +541,15 @@ class ChatApp(App):
         context_file = files("claudechic").joinpath("context.md")
         system_prompt = context_file.read_text()
 
+        # Respect environment variables if set (for agentic-sso proxy)
+        # When ANTHROPIC_BASE_URL is set, don't override ANTHROPIC_API_KEY
+        env: dict[str, str] = {}
+        if not os.environ.get("ANTHROPIC_BASE_URL"):
+            env["ANTHROPIC_API_KEY"] = ""
+
         return ClaudeAgentOptions(
             permission_mode="default",
-            env={"ANTHROPIC_API_KEY": ""},
+            env=env,
             setting_sources=["user", "project", "local"],
             cwd=cwd,
             resume=resume,


### PR DESCRIPTION
Respect ANTHROPIC_BASE_URL environment variable when set. This allows claudechic to work with agentic-sso proxy which sets ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY environment variables for SSO authentication.

When ANTHROPIC_BASE_URL is set, don't override ANTHROPIC_API_KEY with an empty string, allowing the proxy-handled credentials to pass through.