### PR TITLE
Add --theme/-t CLI flag for per-session theme override

### DIFF
--- a/claudechic/__main__.py
+++ b/claudechic/__main__.py
@@ -27,6 +27,14 @@ def main():
         "--session", "-s", type=str, help="Resume a specific session ID"
     )
     parser.add_argument(
+        "--theme",
+        "-t",
+        nargs="?",
+        const="__list__",
+        default=None,
+        help="Use a specific theme for this session, or pass without a value to list available themes",
+    )
+    parser.add_argument(
         "--remote-port",
         type=int,
         default=int(os.environ.get("CLAUDECHIC_REMOTE_PORT", "0")),
@@ -48,6 +56,22 @@ def main():
         args.session if args.session else ("__most_recent__" if args.resume else None)
     )
 
+    # Validate theme name or list available themes
+    if args.theme:
+        from claudechic.theme import get_available_theme_names
+
+        available = get_available_theme_names()
+        if args.theme == "__list__":
+            print("Available themes:")
+            for name in sorted(available):
+                print(f"  {name}")
+            sys.exit(0)
+        if args.theme not in available:
+            print(f"Unknown theme '{args.theme}'. Available themes:")
+            for name in sorted(available):
+                print(f"  {name}")
+            sys.exit(1)
+
     # Set terminal window title (before Textual takes over stdout)
     from pathlib import Path
     from rich.console import Console
@@ -61,6 +85,7 @@ def main():
             initial_prompt=initial_prompt,
             remote_port=args.remote_port,
             skip_permissions=args.dangerously_skip_permissions,
+            theme_override=args.theme,
         )
         app.run()
     except (KeyboardInterrupt, SystemExit):

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -165,6 +165,7 @@ class ChatApp(App):
         initial_prompt: str | None = None,
         remote_port: int = 0,
         skip_permissions: bool = False,
+        theme_override: str | None = None,
     ) -> None:
         super().__init__()
         self.scroll_sensitivity_y = 1.0  # Smoother scrolling (default is 2.0)
@@ -175,6 +176,7 @@ class ChatApp(App):
         self._initial_prompt = initial_prompt
         self._remote_port = remote_port
         self._skip_permissions = skip_permissions
+        self._theme_override = theme_override
         # Event queues for testing
         self.interactions: asyncio.Queue[PermissionRequest] = asyncio.Queue()
         self.completions: asyncio.Queue[ResponseComplete] = asyncio.Queue()
@@ -672,7 +674,7 @@ class ChatApp(App):
         self.register_theme(CHIC_LIGHT_THEME)
         for theme in load_custom_themes():
             self.register_theme(theme)
-        self.theme = CONFIG.get("theme") or "chic"
+        self.theme = self._theme_override or CONFIG.get("theme") or "chic"
 
         # Warn if running in YOLO mode
         if self._skip_permissions:
@@ -714,7 +716,9 @@ class ChatApp(App):
         self._connect_initial_client()
 
     def watch_theme(self, theme: str) -> None:
-        """Save theme preference when changed."""
+        """Save theme preference when changed (skip if overridden by CLI flag)."""
+        if self._theme_override:
+            return
         if theme != CONFIG.get("theme"):
             CONFIG["theme"] = theme
             save_config()

--- a/claudechic/theme.py
+++ b/claudechic/theme.py
@@ -19,7 +19,7 @@ Custom themes can be defined in ~/.claude/.claudechic.yaml:
 Use /theme to search and switch between available themes.
 """
 
-from textual.theme import Theme
+from textual.theme import BUILTIN_THEMES, Theme
 
 from claudechic.config import CONFIG
 
@@ -70,6 +70,15 @@ _THEME_FIELDS = (
     "dark",
 )
 _CHIC_DEFAULTS = {f: getattr(CHIC_THEME, f) for f in _THEME_FIELDS}
+
+
+def get_available_theme_names() -> set[str]:
+    """Return names of all available themes (Textual built-in + claudechic + custom)."""
+    names = set(BUILTIN_THEMES.keys()) | {"chic", "chic-light"}
+    for name, colors in CONFIG.get("themes", {}).items():
+        if isinstance(colors, dict):
+            names.add(name)
+    return names
 
 
 def load_custom_themes() -> list[Theme]:


### PR DESCRIPTION
Allow specifying a color theme at startup so multiple sessions can run simultaneously with distinct visual themes. The CLI-specified theme is not persisted to the config file, keeping sessions independent.

- `claudechic -t rose-pine` starts with that theme
- `claudechic -t` lists all available themes
- Invalid theme names show the available list and exit