### PR TITLE
Fix plan mode: agent can't write to plan file

### DIFF
--- a/claudechic/agent.py
+++ b/claudechic/agent.py
@@ -467,8 +467,8 @@ Key Rules:
 - Don't make large assumptions - ask questions
 - Use AskUserQuestion for requirement clarification
 - Use ExitPlanMode for plan approval (never ask "is this plan okay?" via text)
-- Build plan incrementally by writing/editing the plan file
-- Edit, Write, Bash, and NotebookEdit are NOT available (except writing to the plan file)
+- You MUST write your plan to the plan file using the Write tool. Only that file is writable.
+- Edit, Bash, and NotebookEdit are NOT available in plan mode
 {plan_file_info}
 </system-reminder>
 """
@@ -905,6 +905,8 @@ Key Rules:
             self.plan_path = await get_plan_path_for_session(
                 self.session_id, cwd=self.cwd, must_exist=False
             )
+            if self.plan_path:
+                self.plan_path.parent.mkdir(parents=True, exist_ok=True)
 
     async def set_permission_mode(self, mode: str) -> None:
         """Update permission mode via SDK and emit event.

--- a/claudechic/sessions.py
+++ b/claudechic/sessions.py
@@ -293,7 +293,11 @@ async def get_plan_path_for_session(
         return None
 
     if not slug:
-        return None
+        if must_exist:
+            return None
+        # Fallback: use session_id when slug isn't available yet.
+        # May not match eventual slug-based path, but plan_path is cached per-session.
+        return Path.home() / ".claude" / "plans" / f"{session_id}.md"
 
     plan_path = Path.home() / ".claude" / "plans" / f"{slug}.md"
     if must_exist:


### PR DESCRIPTION
## Summary
- Reword plan mode system prompt to lead with "you MUST write your plan using the Write tool" instead of "Write is NOT available (except...)" — fixes the LLM taking the prohibition literally
- Fall back to `~/.claude/plans/{session_id}.md` when slug isn't available yet, so the prompt always shows a concrete file path
- Ensure `~/.claude/plans/` directory exists before the agent tries to write

Closes #47

## Test plan
- [x] All 218 existing tests pass
- [ ] Start claudechic, trigger `EnterPlanMode`, confirm agent writes to plan file without hesitation
- [ ] Confirm system prompt shows a concrete plan file path (not the fallback text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)