### PR TITLE
Fix session lookup for paths with underscores

### DIFF
--- a/claudechic/sessions.py
+++ b/claudechic/sessions.py
@@ -65,7 +65,7 @@ def get_project_sessions_dir(cwd: Path | None = None) -> Path | None:
     cwd = (cwd or Path.cwd()).absolute()
     # Replace path separators with dashes (handles both / and \ on Windows)
     # Also remove Windows drive colon (C:\foo -> C-foo)
-    project_key = str(cwd).replace(os.sep, "-").replace(":", "").replace(".", "-")
+    project_key = str(cwd).replace(os.sep, "-").replace(":", "").replace("_", "-").replace(".", "-")
     sessions_dir = Path.home() / ".claude/projects" / project_key
     return sessions_dir if sessions_dir.exists() else None
 


### PR DESCRIPTION
## Summary
- Claude Code normalizes underscores to dashes in project directory names (e.g., `/path/to/my_project` → `-path-to-my-project`)
- Without this fix, `get_project_sessions_dir()` fails to find the sessions directory for any project path containing underscores
- This caused the context window bar to not display token usage

## Test plan
- [x] Verified fix works on a project path with underscores that was previously broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Comment by human: When working in projects that have an underscore in their file name, the context window wasn't correctly displayed in claudechic. It always showed 0%. This was due to the way claude determines the project session folder, where it replaces the underscore with a dash. Claudechic was therefore not checking the correct folder, and could not determine how much context was used. This fix addresses that.