### PR TITLE
Add /clearui command to clear UI widgets while preserving session

### DIFF
--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -81,6 +81,7 @@ BARE_WORDS: dict[str, str] = {
 # Variants are additional completions like "/agent close" for "/agent"
 COMMANDS: list[tuple[str, str, list[str]]] = [
     ("/clear", "Clear chat and start new session", []),
+    ("/clearui", "Clear UI widgets (keeps history)", []),
     ("/diff", "Review changes vs target (default HEAD)", []),
     ("/resume", "Resume a previous session", []),
     (
@@ -147,6 +148,8 @@ def get_help_commands() -> list[tuple[str, str]]:
             display_name = "/plan-swarm"
         elif name == "/rewind":
             display_name = "/rewind [index]"
+        elif name == "/clearui":
+            display_name = "/clearui [N]"
         result.append((display_name, desc))
     return result
 
@@ -179,6 +182,10 @@ def handle_command(app: "ChatApp", prompt: str) -> bool:
         _track_command(app, "clear")
         app._start_new_session()
         return True
+
+    if cmd.startswith("/clearui"):
+        _track_command(app, "clearui")
+        return _handle_clearui(app, cmd)
 
     if cmd.startswith("/resume"):
         _track_command(app, "resume")
@@ -738,6 +745,20 @@ def _handle_processes(app: "ChatApp") -> None:
     else:
         processes = []
     app.push_screen(ProcessModal(processes))
+
+
+def _handle_clearui(app: "ChatApp", command: str) -> bool:
+    """Clear UI for all agents, keeping last N widgets each."""
+    parts = command.split(maxsplit=1)
+    keep = 10
+    if len(parts) > 1 and parts[1].strip().isdigit():
+        keep = int(parts[1].strip())
+
+    for chat_view in app._chat_views.values():
+        chat_view.clear_to_recent(keep)
+
+    app.notify(f"Cleared UI (keeping last {keep})")
+    return True
 
 
 def _handle_reviews(app: "ChatApp", job_id: str | None) -> None:

--- a/claudechic/widgets/layout/chat_view.py
+++ b/claudechic/widgets/layout/chat_view.py
@@ -79,6 +79,7 @@ class ChatView(AutoHideScroll):
         self._active_task_widgets: dict[str, TaskWidget] = {}
         self._recent_tools: list[ToolUseWidget | TaskWidget | AgentToolWidget] = []
         self._thinking_indicator: ThinkingIndicator | None = None
+        self._hidden_widget_count: int = 0
 
         # Deferred update tracking for hidden views
         self._needs_rerender: bool = False
@@ -508,3 +509,25 @@ class ChatView(AutoHideScroll):
                 self._thinking_indicator = ThinkingIndicator()
                 self.mount(self._thinking_indicator)
                 self.scroll_end(animate=False)
+
+    def clear_to_recent(self, keep: int = 10) -> None:
+        """Remove all but the most recent N widgets.
+
+        Does NOT affect Agent.messages or JSONL - only UI.
+        """
+        children = list(self.children)
+
+        if len(children) <= keep:
+            return
+
+        # Remove oldest widgets
+        to_remove = children[:-keep]
+        for widget in to_remove:
+            widget.remove()
+
+        # Update hidden count
+        self._hidden_widget_count += len(to_remove)
+
+        # Clean up tracking lists
+        self._recent_tools = [w for w in self._recent_tools if w.parent is not None]
+        self._current_response = None  # Reset streaming state

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -775,3 +775,142 @@ async def test_stop_review_polling_unconditional(mock_sdk):
         fake_timer.stop.assert_called_once()
         assert app._review_poll_timer is None
         assert app._review_poll_agent_id is None
+
+
+# =============================================================================
+# /clearui command
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_clearui_command_keeps_last_10(mock_sdk):
+    """/clearui keeps the last 10 widgets by default."""
+    app = ChatApp()
+    async with app.run_test() as pilot:
+        chat_view = app._chat_view
+        assert chat_view is not None
+
+        # Add 15 messages
+        for i in range(15):
+            msg = ChatMessage(f"Message {i}")
+            chat_view.mount(msg)
+        await pilot.pause()
+
+        assert len(chat_view.children) == 15
+
+        # Send /clearui
+        await submit_command(app, pilot, "/clearui")
+        await pilot.pause()
+
+        # Should keep last 10
+        assert len(chat_view.children) == 10
+        # Hidden count should be updated
+        assert chat_view._hidden_widget_count == 5
+
+
+@pytest.mark.asyncio
+async def test_clearui_command_custom_keep(mock_sdk):
+    """/clearui 3 keeps only last 3 widgets."""
+    app = ChatApp()
+    async with app.run_test() as pilot:
+        chat_view = app._chat_view
+        assert chat_view is not None
+
+        # Add 10 messages
+        for i in range(10):
+            msg = ChatMessage(f"Message {i}")
+            chat_view.mount(msg)
+        await pilot.pause()
+
+        assert len(chat_view.children) == 10
+
+        # Send /clearui 3
+        await submit_command(app, pilot, "/clearui 3")
+        await pilot.pause()
+
+        # Should keep last 3
+        assert len(chat_view.children) == 3
+        assert chat_view._hidden_widget_count == 7
+
+
+@pytest.mark.asyncio
+async def test_clearui_command_fewer_than_keep(mock_sdk):
+    """/clearui with fewer widgets than keep count does nothing."""
+    app = ChatApp()
+    async with app.run_test() as pilot:
+        chat_view = app._chat_view
+        assert chat_view is not None
+
+        # Add only 5 messages (less than default 10)
+        for i in range(5):
+            msg = ChatMessage(f"Message {i}")
+            chat_view.mount(msg)
+        await pilot.pause()
+
+        assert len(chat_view.children) == 5
+
+        # Send /clearui (default keep=10)
+        await submit_command(app, pilot, "/clearui")
+        await pilot.pause()
+
+        # Should keep all 5 (less than 10)
+        assert len(chat_view.children) == 5
+        assert chat_view._hidden_widget_count == 0
+
+
+@pytest.mark.asyncio
+async def test_clearui_command_empty_view(mock_sdk):
+    """/clearui on empty view does nothing."""
+    app = ChatApp()
+    async with app.run_test() as pilot:
+        chat_view = app._chat_view
+        assert chat_view is not None
+
+        # Verify empty
+        assert len(chat_view.children) == 0
+
+        # Send /clearui
+        await submit_command(app, pilot, "/clearui")
+        await pilot.pause()
+
+        # Still empty, no error
+        assert len(chat_view.children) == 0
+        assert chat_view._hidden_widget_count == 0
+
+
+@pytest.mark.asyncio
+async def test_clearui_all_agents(mock_sdk):
+    """/clearui clears UI for all agents."""
+    app = ChatApp()
+    async with app.run_test() as pilot:
+        # Create second agent
+        await submit_command(app, pilot, "/agent second")
+        await wait_for_workers(app)
+
+        assert len(app.agents) == 2
+        agent_ids = list(app.agents.keys())
+
+        # Add messages to both chat views
+        for agent_id in agent_ids:
+            chat_view = app._chat_views.get(agent_id)
+            if chat_view:
+                for i in range(15):
+                    msg = ChatMessage(f"Message {i}")
+                    chat_view.mount(msg)
+        await pilot.pause()
+
+        # Verify both have 15 messages
+        for agent_id in agent_ids:
+            chat_view = app._chat_views.get(agent_id)
+            if chat_view:
+                assert len(chat_view.children) == 15
+
+        # Send /clearui (should affect all agents)
+        await submit_command(app, pilot, "/clearui")
+        await pilot.pause()
+
+        # Both should be reduced to 10
+        for agent_id in agent_ids:
+            chat_view = app._chat_views.get(agent_id)
+            if chat_view:
+                assert len(chat_view.children) == 10


### PR DESCRIPTION
# PR: Add `/clearui` command to clear UI widgets while preserving session

I notice a slowdown in claudechic if the number of messages gets very long. Performance was improved for me in long sessions with a recent commit (I think 82c3bb1: CSS recalc performance - batching streaming mounts, removing expensive CSS selectors), but I still experience a slowdown in very long sessions. 

I suggest to include the following command

```
/clearui [N]    # Keep last N widgets (default: 10)
```

Running this in claudechic keeps the last N messages in the TUI. The tradeoff is that earlier messages are not accessible any more. But the responsiveness is back at initial speeds. 

Below is an AI generated summary:

## Summary

Adds a `/clearui` command that removes old UI widgets from the display while keeping session history intact. This addresses performance degradation in long-running TUI sessions that accumulate many widgets.

## Motivation

In long claudechic sessions, the Textual DOM can accumulate hundreds or thousands of widgets (ChatMessage, ToolUseWidget, TaskWidget, etc.), causing:
- Slower rendering and increased CPU usage
- Memory growth from retained widget state
- Degraded responsiveness in the TUI

Users need a way to prune old UI elements without losing their conversation history or starting a fresh session.

## Implementation

### Command Usage
```
/clearui [N]    # Keep last N widgets (default: 10)
```

### What it does
- Removes oldest widgets from ChatView DOM
- Preserves Agent.messages (session history)
- Preserves JSONL persistence
- Does NOT trigger SDK reconnect/compact
- Updates internal tracking for "N widgets hidden" indicator

### Key Design
Clean separation at the UI layer:
- `ChatView.clear_to_recent(keep)` operates only on `self.children` (Textual widgets)
- Does NOT touch `agent.messages` or session state
- Simple, focused interface with no side effects

## Changes

### Files Modified
1. **`claudechic/commands.py`** (~15 lines)
   - Add `/clearui` to COMMANDS registry
   - Add `_handle_clearui()` handler
   - Add routing and analytics tracking

2. **`claudechic/widgets/layout/chat_view.py`** (~23 lines)
   - Add `_hidden_widget_count` attribute for tracking
   - Add `clear_to_recent(keep: int = 10)` method

3. **`tests/test_app_ui.py`** (~139 lines)
   - `test_clearui_command_keeps_last_10` - Default behavior
   - `test_clearui_command_custom_keep` - Custom N parameter
   - `test_clearui_command_fewer_than_keep` - Edge case handling
   - `test_clearui_command_empty_view` - Empty view handling
   - `test_clearui_all_agents` - Multi-agent clearing

### Total: 183 lines added, 0 removed

## Testing

All existing tests pass + 5 new tests covering:
- Default retention (N=10)
- Custom retention values
- Edge cases (fewer widgets than N, empty views)
- Multi-agent scenarios

```
============================= 41 passed in 17.56s ==============================
```

## Example Usage

```python
# User has accumulated 100+ widgets over long session
/clearui          # Keeps last 10, removes 90+
# → "Cleared UI (keeping last 10)"

/clearui 3        # Keep only last 3 widgets
# → "Cleared UI (keeping last 3)"
```

## Comparison with `/clear`

| Command | UI | Session | Use Case |
|---------|-----|---------|----------|
| `/clear` | Clears | Starts fresh | Start new conversation |
| `/clearui` | Clears old | Preserves | Clean up display, continue session |

## Implementation Notes

- Follows existing command patterns (registry, help hints, routing)
- Uses same analytics tracking as other commands
- Consistent with claudechic's widget lifecycle management
- No breaking changes to existing functionality

## Checklist

- [x] Implementation complete
- [x] Tests added and passing
- [x] No breaking changes
- [x] Follows existing code patterns
- [x] Documentation in command help text

---

Ready for review! Happy to address any feedback or concerns.