### PR TITLE
Add worktree.enabled config flag to skip git worktree operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,4 +31,13 @@ Branch: `worktree-disable-config` | PR: https://github.com/mrocklin/claudechic/p
 
 ## UI
 
-**Context-mode MCP tools collapse by default** — tools whose names start with `mcp__plugin_context-mode` now start collapsed, same as `Read`, `Grep`, etc. Reduces noise from sandbox utility tools that run frequently.
+**Configurable MCP tool collapse prefixes** — any MCP tool whose name starts with a configured prefix starts collapsed. Built-in defaults: `mcp__plugin_context-mode`, `mcp__searxng`. Override or extend in `.claudechic.yaml`:
+
+```yaml
+collapse-tool-prefixes:
+  - mcp__plugin_context-mode
+  - mcp__searxng
+  - mcp__your_other_tool
+```
+
+If the key is absent, built-in defaults apply. Set to an empty list `[]` to disable prefix collapsing entirely.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,9 @@ Branch: `worktree-disable-config` | PR: https://github.com/mrocklin/claudechic/p
 
 **`remote_port` config key** — set `remote_port: 9001` in `.claudechic.yaml` to auto-start the HTTP server on that port without needing the `--remote-port` CLI flag every launch.
 
-**Graceful port-in-use handling** — if the configured remote port is already held by a previous session, ClaudeChic now shows a warning notification and continues starting normally instead of crashing silently.
+**Graceful port-in-use handling** — if the configured remote port is already held by a previous session, ClaudeChic automatically finds and kills the stale Python process, waits 0.5s, then retries. Only kills Python processes (won't touch unrelated services). Falls back to a warning notification if the retry also fails.
+
+**Clipboard paste no longer freezes window** — `PIL.ImageGrab.grabclipboard()` was called synchronously on the event loop, blocking the entire UI while Windows read and converted the screenshot. Now runs in a thread via `asyncio.to_thread()`. Screenshot pastes are non-blocking.
 
 ## Windows session fixes
 
@@ -41,3 +43,9 @@ collapse-tool-prefixes:
 ```
 
 If the key is absent, built-in defaults apply. Set to an empty list `[]` to disable prefix collapsing entirely.
+
+**Plan review no longer hangs** — `ExitPlanMode` was rendering plan content as a Textual `Markdown` widget, which spawns hundreds of child widgets for large plans and blocks the layout thread. Also had a double-render path via `_try_update_plan_content`. Fixed by using `Static(markup=False)` (plain text, instantaneous) and applying the same lazy `content_factory` pattern as `Edit` for collapsed history items.
+
+**Startup crash fix** — `config.setdefault("collapse-tool-prefixes", None)` stored `None` in the config dict. `dict.get(key, default)` returns the stored `None` (key exists), causing `tuple(None)` to crash at import time. Fixed with `CONFIG.get("collapse-tool-prefixes") or _DEFAULT_COLLAPSE_PREFIXES`.
+
+**Desktop shortcut launches ClaudeChic** — `Claude.bat` updated to launch `python -m claudechic` with `ANTHROPIC_MODEL` + `ANTHROPIC_SMALL_MODEL` env vars for model selection, instead of the raw `claude.cmd` CLI.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,34 @@
+# Changes from upstream
+
+This fork adds Windows compatibility fixes and quality-of-life improvements.
+Branch: `worktree-disable-config` | PR: https://github.com/mrocklin/claudechic/pull/61
+
+---
+
+## Worktree
+
+**`worktree.enabled` config flag** — set `worktree: enabled: false` in `.claudechic.yaml` to disable git worktree operations entirely. Prevents UI hangs caused by `EnterWorktree`/`ExitWorktree` git operations. When disabled, subagents run in the current directory instead of spinning up isolated worktrees.
+
+## Clipboard / image paste
+
+**Raw clipboard image support** — pasting a screenshot (Win+Shift+S, ShareX, etc.) now works via PIL fallback. Previously only file paths were detected; raw image data was silently dropped. Saves clipboard image to a temp file and attaches it as normal.
+
+**ShareX HTTP endpoint** — `POST /attach-image` added to the remote control server. Accepts `{"path": "/abs/path/to/image.png"}`. Lets external tools (ShareX custom actions, scripts) attach images without clipboard involvement.
+
+**`remote_port` config key** — set `remote_port: 9001` in `.claudechic.yaml` to auto-start the HTTP server on that port without needing the `--remote-port` CLI flag every launch.
+
+**Graceful port-in-use handling** — if the configured remote port is already held by a previous session, ClaudeChic now shows a warning notification and continues starting normally instead of crashing silently.
+
+## Windows session fixes
+
+**Session path bug** — `get_project_sessions_dir()` was stripping the drive colon (`C:\foo` → `C-foo`) instead of replacing it with a dash (`C--foo`). Claude Code uses the dash form, so the session directory was never found. Context bar showed zero tokens; session history failed to load.
+
+**UTF-8 encoding** — session JSONL files are UTF-8 but `aiofiles.open()` defaulted to the Windows system encoding (cp1252). Fixed by adding `encoding="utf-8"`. Prevents `UnicodeDecodeError` when loading sessions containing emoji or non-ASCII characters.
+
+## Error handling
+
+**Worker errors show as notifications** — previously, any background worker failure (`exit_on_error=True`) crashed the whole app and closed the window with no explanation. All workers now use `exit_on_error=False`. A central `on_worker_state_changed` handler catches failures and shows a red corner notification with the error message (10s timeout).
+
+## UI
+
+**Context-mode MCP tools collapse by default** — tools whose names start with `mcp__plugin_context-mode` now start collapsed, same as `Read`, `Grep`, etc. Reduces noise from sandbox utility tools that run frequently.

--- a/claudechic/__main__.py
+++ b/claudechic/__main__.py
@@ -79,11 +79,16 @@ def main():
 
     Console().control(Control.title(f"Claude Chic · {Path.cwd().name}"))
 
+    # Fall through to config if --remote-port not explicitly set
+    from claudechic.config import CONFIG
+
+    remote_port = args.remote_port or CONFIG.get("remote_port", 0)
+
     try:
         app = ChatApp(
             resume_session_id=resume_id,
             initial_prompt=initial_prompt,
-            remote_port=args.remote_port,
+            remote_port=remote_port,
             skip_permissions=args.dangerously_skip_permissions,
             theme_override=args.theme,
         )

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -25,6 +25,7 @@ from textual.binding import Binding
 from textual.containers import Vertical, Horizontal
 from textual.events import MouseUp
 from textual import work
+from textual.worker import Worker, WorkerState
 
 from claude_agent_sdk import (
     CLIConnectionError,
@@ -758,7 +759,7 @@ class ChatApp(App):
             CONFIG["theme"] = theme
             save_config()
 
-    @work(exclusive=True, group="connect")
+    @work(exclusive=True, group="connect", exit_on_error=False)
     async def _connect_initial_client(self) -> None:
         """Connect SDK for the initial agent."""
         if self.agent_mgr is None or self.agent_mgr.active is None:
@@ -884,7 +885,7 @@ class ChatApp(App):
 
         autocomplete.slash_commands = base
 
-    @work(exclusive=True, group="file_index")
+    @work(exclusive=True, group="file_index", exit_on_error=False)
     async def _refresh_file_index(self) -> None:
         """Refresh the file index in the background."""
         if self.file_index:
@@ -966,7 +967,7 @@ class ChatApp(App):
             chat_view._render_full()
             self.call_after_refresh(chat_view.scroll_if_tailing)
 
-    @work(group="refresh_context", exclusive=True)
+    @work(group="refresh_context", exclusive=True, exit_on_error=False)
     async def refresh_context(self) -> None:
         """Update context bar from session file (no API call)."""
         agent = self._agent
@@ -2214,6 +2215,14 @@ class ChatApp(App):
         await self.agent_mgr.close(agent_id)
 
         self.notify(f"Agent '{agent_name}' closed")
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        """Show a notification instead of crashing when a worker fails."""
+        if event.state == WorkerState.ERROR and event.worker.error:
+            error = event.worker.error
+            msg = str(error) or type(error).__name__
+            log.error("Worker %s failed: %s", event.worker.name, msg, exc_info=error)
+            self.notify(msg, title="Error", severity="error", timeout=10)
 
     def on_app_focus(self) -> None:
         if self._chat_input:

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -680,7 +680,16 @@ class ChatApp(App):
         if self._remote_port:
             from claudechic.remote import start_server
 
-            await start_server(self, self._remote_port)
+            try:
+                await start_server(self, self._remote_port)
+            except OSError as e:
+                log.warning(
+                    f"Remote control server failed on port {self._remote_port}: {e}"
+                )
+                self.notify(
+                    f"Remote port {self._remote_port} already in use — remote control disabled",
+                    severity="warning",
+                )
 
         # Register themes (chic default + light variant + user-defined from config)
         self.register_theme(CHIC_THEME)
@@ -2232,6 +2241,21 @@ class ChatApp(App):
 
             for path in images:
                 self._attach_image(path)
+            event.prevent_default()
+            event.stop()
+            return
+
+        # Fallback: raw clipboard image (e.g. Win+Shift+S screenshot)
+        clipboard_image = self._chat_input._grab_clipboard_image()
+        if clipboard_image:
+            now = time.time()
+            last = self._chat_input._last_image_paste
+            if last and now - last[1] < 0.5:
+                event.prevent_default()
+                event.stop()
+                return
+            self._chat_input._last_image_paste = ("__clipboard__", now)
+            self._attach_image(clipboard_image)
             event.prevent_default()
             event.stop()
 

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -625,6 +625,10 @@ class ChatApp(App):
         if os.environ.get("VIRTUAL_ENV"):
             env["VIRTUAL_ENV"] = ""
 
+        # Disable worktree isolation for subagents if worktrees are disabled in config
+        worktrees_enabled = CONFIG.get("worktree", {}).get("enabled", True)
+        disallowed = [] if worktrees_enabled else ["EnterWorktree", "ExitWorktree"]
+
         return ClaudeAgentOptions(
             permission_mode="bypassPermissions"
             if self._skip_permissions
@@ -640,6 +644,7 @@ class ChatApp(App):
             hooks=self._plan_mode_hooks(),
             enable_file_checkpointing=True,
             extra_args={"replay-user-messages": None},
+            disallowed_tools=disallowed,
         )
 
     async def on_mount(self) -> None:
@@ -858,14 +863,15 @@ class ChatApp(App):
                 base.append(f"/agent close {agent.name}")
 
         # Add current worktrees
-        try:
-            from claudechic.features.worktree import list_worktrees
+        if CONFIG.get("worktree", {}).get("enabled", True):
+            try:
+                from claudechic.features.worktree import list_worktrees
 
-            for wt in list_worktrees():
-                if not wt.is_main:
-                    base.append(f"/worktree {wt.branch}")
-        except Exception:
-            pass  # Not a git repo or git not available
+                for wt in list_worktrees():
+                    if not wt.is_main:
+                        base.append(f"/worktree {wt.branch}")
+            except Exception:
+                pass  # Not a git repo or git not available
 
         autocomplete.slash_commands = base
 
@@ -1904,6 +1910,8 @@ class ChatApp(App):
 
     def _populate_worktrees(self) -> None:
         """Populate sidebar with ghost worktrees for feature branches."""
+        if not CONFIG.get("worktree", {}).get("enabled", True):
+            return
         try:
             worktrees = list_worktrees()
         except Exception:

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -126,6 +126,29 @@ def _categorize_cli_error(e: CLIConnectionError) -> str:
     return "unknown"
 
 
+def _kill_port(port: int) -> None:
+    """Kill whatever process is holding the given port so we can rebind."""
+    import subprocess
+    try:
+        if sys.platform == "win32":
+            result = subprocess.run(
+                ["netstat", "-ano"], capture_output=True, text=True, timeout=5
+            )
+            for line in result.stdout.splitlines():
+                if f":{port} " in line and "LISTENING" in line:
+                    pid = line.strip().split()[-1]
+                    if pid != "0":
+                        subprocess.run(
+                            ["cmd", "/c", f"taskkill /PID {pid} /F"],
+                            capture_output=True, timeout=5,
+                        )
+                    break
+        else:
+            subprocess.run(["fuser", "-k", f"{port}/tcp"], capture_output=True, timeout=5)
+    except Exception:
+        pass
+
+
 class ChatApp(App):
     """Main chat application.
 
@@ -683,14 +706,20 @@ class ChatApp(App):
 
             try:
                 await start_server(self, self._remote_port)
-            except OSError as e:
-                log.warning(
-                    f"Remote control server failed on port {self._remote_port}: {e}"
-                )
-                self.notify(
-                    f"Remote port {self._remote_port} already in use — remote control disabled",
-                    severity="warning",
-                )
+            except OSError:
+                # Port held by previous session — kill it and retry
+                _kill_port(self._remote_port)
+                await asyncio.sleep(0.5)
+                try:
+                    await start_server(self, self._remote_port)
+                except OSError as e:
+                    log.warning(
+                        f"Remote control server failed on port {self._remote_port}: {e}"
+                    )
+                    self.notify(
+                        f"Remote port {self._remote_port} already in use — remote control disabled",
+                        severity="warning",
+                    )
 
         # Register themes (chic default + light variant + user-defined from config)
         self.register_theme(CHIC_THEME)

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -126,8 +126,12 @@ def _categorize_cli_error(e: CLIConnectionError) -> str:
     return "unknown"
 
 
-def _kill_port(port: int) -> None:
-    """Kill whatever process is holding the given port so we can rebind."""
+def _kill_port(port: int) -> bool:
+    """Kill a stale ClaudeChic process holding the given port.
+
+    Only kills Python processes — won't touch unrelated services on the port.
+    Returns True if a process was killed, False otherwise.
+    """
     import subprocess
     try:
         if sys.platform == "win32":
@@ -137,16 +141,26 @@ def _kill_port(port: int) -> None:
             for line in result.stdout.splitlines():
                 if f":{port} " in line and "LISTENING" in line:
                     pid = line.strip().split()[-1]
-                    if pid != "0":
+                    if pid == "0" or pid == str(os.getpid()):
+                        return False
+                    # Only kill if it's a Python process (i.e. a stale ClaudeChic)
+                    names = subprocess.run(
+                        ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+                        capture_output=True, text=True, timeout=5,
+                    )
+                    if "python" in names.stdout.lower():
                         subprocess.run(
                             ["cmd", "/c", f"taskkill /PID {pid} /F"],
                             capture_output=True, timeout=5,
                         )
-                    break
+                        return True
+                    return False
         else:
             subprocess.run(["fuser", "-k", f"{port}/tcp"], capture_output=True, timeout=5)
+            return True
     except Exception:
         pass
+    return False
 
 
 class ChatApp(App):
@@ -708,14 +722,19 @@ class ChatApp(App):
                 await start_server(self, self._remote_port)
             except OSError:
                 # Port held by previous session — kill it and retry
-                _kill_port(self._remote_port)
-                await asyncio.sleep(0.5)
-                try:
-                    await start_server(self, self._remote_port)
-                except OSError as e:
-                    log.warning(
-                        f"Remote control server failed on port {self._remote_port}: {e}"
-                    )
+                if _kill_port(self._remote_port):
+                    await asyncio.sleep(0.5)
+                    try:
+                        await start_server(self, self._remote_port)
+                    except OSError as e:
+                        log.warning(
+                            f"Remote control server failed on port {self._remote_port}: {e}"
+                        )
+                        self.notify(
+                            f"Remote port {self._remote_port} already in use — remote control disabled",
+                            severity="warning",
+                        )
+                else:
                     self.notify(
                         f"Remote port {self._remote_port} already in use — remote control disabled",
                         severity="warning",

--- a/claudechic/config.py
+++ b/claudechic/config.py
@@ -35,6 +35,7 @@ def _load() -> tuple[dict, bool]:
         config.setdefault("worktree", {})
         config["worktree"].setdefault("path_template", None)
         config["worktree"].setdefault("enabled", True)
+        config.setdefault("remote_port", 0)
         # Migrate legacy vim key to vi-mode
         if "vim" in config:
             config["vi-mode"] = config.pop("vim")

--- a/claudechic/config.py
+++ b/claudechic/config.py
@@ -36,6 +36,7 @@ def _load() -> tuple[dict, bool]:
         config["worktree"].setdefault("path_template", None)
         config["worktree"].setdefault("enabled", True)
         config.setdefault("remote_port", 0)
+        config.setdefault("collapse-tool-prefixes", None)  # None = use built-in defaults
         # Migrate legacy vim key to vi-mode
         if "vim" in config:
             config["vi-mode"] = config.pop("vim")

--- a/claudechic/config.py
+++ b/claudechic/config.py
@@ -34,6 +34,7 @@ def _load() -> tuple[dict, bool]:
         config.setdefault("experimental", {})
         config.setdefault("worktree", {})
         config["worktree"].setdefault("path_template", None)
+        config["worktree"].setdefault("enabled", True)
         # Migrate legacy vim key to vi-mode
         if "vim" in config:
             config["vi-mode"] = config.pop("vim")

--- a/claudechic/formatting.py
+++ b/claudechic/formatting.py
@@ -149,6 +149,56 @@ def format_result_summary(name: str, content: str, is_error: bool = False) -> st
     return ""
 
 
+_MCP_LABELS: dict[str, str] = {
+    # Context-mode sandbox tools
+    "mcp__plugin_context-mode_context-mode__ctx_execute": "Run Code",
+    "mcp__plugin_context-mode_context-mode__ctx_execute_file": "Analyze File",
+    "mcp__plugin_context-mode_context-mode__ctx_search": "Search Context",
+    "mcp__plugin_context-mode_context-mode__ctx_batch_execute": "Batch Run",
+    "mcp__plugin_context-mode_context-mode__ctx_fetch_and_index": "Fetch & Index",
+    "mcp__plugin_context-mode_context-mode__ctx_index": "Index Content",
+    "mcp__plugin_context-mode_context-mode__ctx_stats": "Context Stats",
+    "mcp__plugin_context-mode_context-mode__ctx_doctor": "Context Doctor",
+    "mcp__plugin_context-mode_context-mode__ctx_upgrade": "Context Upgrade",
+    # SearXNG
+    "mcp__searxng__searxng_web_search": "Web Search",
+    "mcp__searxng__web_url_read": "Read URL",
+    # QMD vault
+    "mcp__qmd__query": "Vault Search",
+    "mcp__qmd__get": "Vault Get",
+    "mcp__qmd__multi_get": "Vault Multi-Get",
+    "mcp__qmd__status": "Vault Status",
+}
+
+
+def _format_mcp_header(name: str, input: dict) -> str:
+    """Format an MCP tool name as a readable label with key input context."""
+    label = _MCP_LABELS.get(name)
+    if not label:
+        # Generic: mcp__server__tool_name → Server: Tool Name
+        parts = name.split("__", 2)
+        if len(parts) == 3:
+            server = parts[1].replace("-", " ").replace("_", " ").split()[0].title()
+            tool = parts[2].replace("_", " ").title()
+            label = f"{server}: {tool}"
+        else:
+            return name
+
+    # Append the most useful input snippet for known search/fetch tools
+    for key in ("query", "searches", "url", "path", "code"):
+        val = input.get(key)
+        if val:
+            if isinstance(val, list) and val:
+                val = val[0]
+            if isinstance(val, dict):
+                val = val.get("query") or val.get("q") or val.get("type", "")
+            snippet = str(val).strip()[:50]
+            if snippet:
+                return f"{label}: {snippet}"
+
+    return label
+
+
 def format_tool_header(name: str, input: dict, cwd: Path | None = None) -> str:
     """Format a one-line header for a tool use."""
     if name == ToolName.EDIT:
@@ -203,6 +253,8 @@ def format_tool_header(name: str, input: dict, cwd: Path | None = None) -> str:
         return "EnterPlanMode"
     elif name == ToolName.EXIT_PLAN_MODE:
         return "ExitPlanMode"
+    elif name.startswith("mcp__"):
+        return _format_mcp_header(name, input)
     else:
         return f"{name}"
 

--- a/claudechic/formatting.py
+++ b/claudechic/formatting.py
@@ -184,17 +184,40 @@ def _format_mcp_header(name: str, input: dict) -> str:
         else:
             return name
 
-    # Append the most useful input snippet for known search/fetch tools
-    for key in ("query", "searches", "url", "path", "code"):
-        val = input.get(key)
-        if val:
-            if isinstance(val, list) and val:
-                val = val[0]
-            if isinstance(val, dict):
-                val = val.get("query") or val.get("q") or val.get("type", "")
-            snippet = str(val).strip()[:50]
-            if snippet:
-                return f"{label}: {snippet}"
+    # Append the most useful input snippet based on what the tool actually uses
+    # intent: qmd__query has a human-readable intent field
+    if "intent" in input:
+        return f"{label}: {str(input['intent'])[:50]}"
+    # query: direct search terms (searxng)
+    if "query" in input:
+        return f"{label}: {str(input['query'])[:50]}"
+    # searches: qmd search array — use first query string
+    if "searches" in input:
+        searches = input["searches"]
+        if isinstance(searches, list) and searches:
+            first = searches[0]
+            q = first.get("query") or first.get("q") if isinstance(first, dict) else str(first)
+            if q:
+                return f"{label}: {str(q)[:50]}"
+    # language: ctx_execute / ctx_execute_file — show language mode
+    if "language" in input:
+        lang = str(input["language"])
+        # For file analysis also show the filename
+        if "path" in input:
+            fname = Path(input["path"]).name
+            return f"{label}: {fname} ({lang})"
+        return f"{label}: {lang}"
+    # url: web fetch tools
+    if "url" in input:
+        return f"{label}: {str(input['url'])[:50]}"
+    # path: vault get — show just the filename
+    if "path" in input:
+        fname = Path(input["path"]).name
+        return f"{label}: {fname}"
+    # commands: ctx_batch_execute — show count
+    if "commands" in input:
+        n = len(input["commands"]) if isinstance(input["commands"], list) else "?"
+        return f"{label} ({n} cmds)"
 
     return label
 

--- a/claudechic/remote.py
+++ b/claudechic/remote.py
@@ -263,6 +263,30 @@ async def handle_key(request: web.Request) -> web.Response:
         return web.json_response({"error": str(e)}, status=500)
 
 
+async def handle_attach_image(request: web.Request) -> web.Response:
+    """Attach an image file to the active agent's pending images.
+
+    Body: {"path": "/absolute/path/to/image.png"}
+
+    Used by ShareX custom action to auto-attach captures without manual paste.
+    """
+    if _app is None:
+        return web.json_response({"error": "App not initialized"}, status=500)
+
+    try:
+        data = await request.json()
+        path_str = data.get("path")
+        if not path_str:
+            return web.json_response({"error": "Missing 'path' field"}, status=400)
+        path = Path(path_str)
+        if not path.exists():
+            return web.json_response({"error": f"File not found: {path}"}, status=404)
+        _app._attach_image(path)
+        return web.json_response({"ok": True, "filename": path.name})
+    except Exception as e:
+        return web.json_response({"error": str(e)}, status=500)
+
+
 async def handle_exit(request: web.Request) -> web.Response:  # noqa: ARG001
     """Exit the app cleanly. Use this before restarting."""
     if _app is None:
@@ -291,6 +315,7 @@ async def start_server(app: ChatApp, port: int) -> None:
     webapp.router.add_get("/status", handle_status)
     webapp.router.add_post("/exit", handle_exit)
     webapp.router.add_post("/key", handle_key)
+    webapp.router.add_post("/attach-image", handle_attach_image)
 
     runner = web.AppRunner(webapp)
     await runner.setup()

--- a/claudechic/screens/session.py
+++ b/claudechic/screens/session.py
@@ -103,7 +103,7 @@ class SessionScreen(Screen[str | None]):
         """Return to chat without selecting a session."""
         self.dismiss(None)
 
-    async def _fetch_sessions(self, search: str) -> list[tuple[str, str, float, int]]:
+    async def _fetch_sessions(self, search: str) -> list[tuple[str, str, float, int, str]]:
         from claudechic.sessions import get_recent_sessions
 
         return await get_recent_sessions(search=search, cwd=self._cwd)
@@ -115,8 +115,8 @@ class SessionScreen(Screen[str | None]):
         sessions = await self._fetch_sessions(search)
         list_view = self.query_one("#session-list", ListView)
         list_view.clear()
-        for session_id, title, mtime, msg_count in sessions:
-            list_view.append(SessionItem(session_id, title, mtime, msg_count))
+        for session_id, title, mtime, msg_count, last_msg in sessions:
+            list_view.append(SessionItem(session_id, title, mtime, msg_count, last_msg))
         if sessions:
             list_view.index = 0
 

--- a/claudechic/sessions.py
+++ b/claudechic/sessions.py
@@ -64,8 +64,8 @@ def get_project_sessions_dir(cwd: Path | None = None) -> Path | None:
     """
     cwd = (cwd or Path.cwd()).absolute()
     # Replace path separators with dashes (handles both / and \ on Windows)
-    # Also remove Windows drive colon (C:\foo -> C-foo)
-    project_key = str(cwd).replace(os.sep, "-").replace(":", "").replace("_", "-").replace(".", "-")
+    # Replace Windows drive colon with dash (C:\foo -> C--foo, matching Claude Code's format)
+    project_key = str(cwd).replace(os.sep, "-").replace(":", "-").replace("_", "-").replace(".", "-")
     sessions_dir = Path.home() / ".claude/projects" / project_key
     return sessions_dir if sessions_dir.exists() else None
 
@@ -220,7 +220,7 @@ async def load_session_messages(session_id: str, cwd: Path | None = None) -> lis
     skip_tags = ("<command-name>/", "<local-command-stdout>", "<local-command-caveat>")
     messages = []
     try:
-        async with aiofiles.open(session_file) as f:
+        async with aiofiles.open(session_file, encoding="utf-8") as f:
             async for line in f:
                 d = json.loads(line)
                 if d.get("type") == "user":

--- a/claudechic/sessions.py
+++ b/claudechic/sessions.py
@@ -84,16 +84,19 @@ def _get_session_file(
     return session_file if session_file.exists() else None
 
 
-def _extract_session_info(filepath: Path) -> tuple[str, int, float]:
-    """Extract title, message count, and timestamp from a session file.
+def _extract_session_info(filepath: Path) -> tuple[str, int, float, str]:
+    """Extract title, message count, timestamp, and last message from a session file.
 
     Claude Code uses summary field if available, otherwise first user message.
     Counts non-meta user entries.
 
-    Returns (title, msg_count, last_timestamp_unix).
+    Returns (title, msg_count, last_timestamp_unix, last_msg).
+    last_msg is the last meaningful user message (>10 chars), useful as a
+    "where you left off" hint in the session picker.
     """
     summary = ""
     first_msg = ""
+    last_msg = ""
     msg_count = 0
     last_timestamp: float = 0
 
@@ -110,21 +113,26 @@ def _extract_session_info(filepath: Path) -> tuple[str, int, float]:
                     if msg_type == "summary":
                         summary = d.get("summary", "")
 
-                    # Count and extract first message
+                    # Count and extract first/last message
                     elif msg_type == "user" and not d.get("isMeta"):
                         msg_count += 1
-                        # Extract first message as fallback title
-                        if not first_msg:
-                            content = d.get("message", {}).get("content", "")
-                            if isinstance(content, str) and content.strip():
-                                if not content.startswith("<command-"):
-                                    first_msg = content.replace("\n", " ")[:100]
-                            elif isinstance(content, list) and content:
-                                block = content[0]
-                                if block.get("type") == "text":
-                                    txt = block.get("text", "")
-                                    if txt.strip() and not txt.startswith("<command-"):
-                                        first_msg = txt.replace("\n", " ")[:100]
+                        content = d.get("message", {}).get("content", "")
+                        text = ""
+                        if isinstance(content, str) and content.strip():
+                            if not content.startswith("<command-"):
+                                text = content.replace("\n", " ")[:100]
+                        elif isinstance(content, list) and content:
+                            block = content[0]
+                            if block.get("type") == "text":
+                                txt = block.get("text", "")
+                                if txt.strip() and not txt.startswith("<command-"):
+                                    text = txt.replace("\n", " ")[:100]
+                        if text:
+                            if not first_msg:
+                                first_msg = text
+                            # Track last meaningful message (skip short acks like "ok", "yes")
+                            if len(text) > 10:
+                                last_msg = text
 
                     # Track timestamp from any entry
                     if ts := d.get("timestamp"):
@@ -140,12 +148,12 @@ def _extract_session_info(filepath: Path) -> tuple[str, int, float]:
 
     # Prefer summary over first message
     title = summary or first_msg
-    return title, msg_count, last_timestamp
+    return title, msg_count, last_timestamp, last_msg
 
 
 async def get_recent_sessions(
     limit: int = 20, search: str = "", cwd: Path | None = None
-) -> list[tuple[str, str, float, int]]:
+) -> list[tuple[str, str, float, int, str]]:
     """Get recent sessions from session files (matching Claude Code behavior).
 
     Args:
@@ -186,18 +194,18 @@ async def get_recent_sessions(
         if i >= scan_limit:
             break
 
-        title, msg_count, last_ts = _extract_session_info(f)
+        title, msg_count, last_ts, last_msg = _extract_session_info(f)
 
         if msg_count == 0:
             continue
 
         title = title or f.stem[:8]
-        if search and search_lower not in title.lower():
+        if search and search_lower not in title.lower() and search_lower not in last_msg.lower():
             continue
 
         # Prefer timestamp from file content over file mtime
         effective_time = last_ts or mtime
-        sessions.append((f.stem, title, effective_time, msg_count))
+        sessions.append((f.stem, title, effective_time, msg_count, last_msg))
 
     # Sort by content timestamp (more accurate than file mtime)
     sessions.sort(key=lambda x: x[2], reverse=True)

--- a/claudechic/widgets/content/message.py
+++ b/claudechic/widgets/content/message.py
@@ -1,8 +1,17 @@
 """Chat widgets - messages, input, and thinking indicator."""
 
 import re
+import tempfile
 import time
 from pathlib import Path
+
+try:
+    from PIL import ImageGrab as _ImageGrab
+
+    _HAS_PIL = True
+except ImportError:
+    _ImageGrab = None
+    _HAS_PIL = False
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -485,6 +494,26 @@ class ChatInput(TextArea):
                 images.append(path)
         return images
 
+    def _grab_clipboard_image(self) -> Path | None:
+        """Grab raw image data from clipboard and save to a temp file.
+
+        Returns path to saved PNG, or None if clipboard has no image.
+        Used as fallback when pasted text is not a file path (e.g. screenshots).
+        """
+        if not _HAS_PIL:
+            return None
+        try:
+            img = _ImageGrab.grabclipboard()
+            if img is None or not hasattr(img, "save"):
+                return None
+            tmp_dir = Path(tempfile.gettempdir()) / "claudechic_paste"
+            tmp_dir.mkdir(exist_ok=True)
+            tmp_path = tmp_dir / f"paste_{int(time.time() * 1000)}.png"
+            img.save(tmp_path, "PNG")
+            return tmp_path
+        except Exception:
+            return None
+
     def on_paste(self, event) -> None:
         """Intercept paste - check for images BEFORE inserting text."""
         images = self._is_image_path(event.text)
@@ -501,6 +530,19 @@ class ChatInput(TextArea):
             # Attach images
             for path in images:
                 self.app._attach_image(path)  # type: ignore[attr-defined]
+            event.prevent_default()
+            event.stop()
+            return
+        # Fallback: raw clipboard image (e.g. Win+Shift+S screenshot)
+        clipboard_image = self._grab_clipboard_image()
+        if clipboard_image:
+            now = time.time()
+            if self._last_image_paste and now - self._last_image_paste[1] < 0.5:
+                event.prevent_default()
+                event.stop()
+                return
+            self._last_image_paste = ("__clipboard__", now)
+            self.app._attach_image(clipboard_image)  # type: ignore[attr-defined]
             event.prevent_default()
             event.stop()
             return

--- a/claudechic/widgets/content/message.py
+++ b/claudechic/widgets/content/message.py
@@ -144,14 +144,18 @@ class ChatMessage(Static):
         return bool(self._pending_text) or self._flush_timer is not None
 
     def compose(self) -> ComposeResult:
-        # Only render initial content - streaming content goes through MarkdownStream
-        # This prevents duplication when append_content() is called before compose() runs
-        if self._is_agent:
-            # Wrap in container for nested border effect
-            with Vertical(id="agent-inner"):
-                yield Markdown(self._initial_content, id="content")
+        # History messages (non-empty content): render as Markdown immediately.
+        # New streaming messages (empty content): start with Static for zero-cost updates.
+        # Static is swapped to Markdown once streaming completes (see flush()).
+        if self._initial_content:
+            inner = Markdown(self._initial_content, id="content")
         else:
-            yield Markdown(self._initial_content, id="content")
+            inner = Static("", id="content", markup=False)
+        if self._is_agent:
+            with Vertical(id="agent-inner"):
+                yield inner
+        else:
+            yield inner
 
     def _get_stream(self):
         """Get or create the MarkdownStream for this message."""
@@ -185,8 +189,7 @@ class ChatMessage(Static):
             )
 
     def _flush_pending(self) -> None:
-        """Flush accumulated text to the MarkdownStream."""
-        # Cancel any pending timer
+        """Flush accumulated text to the content widget."""
         if self._flush_timer is not None:
             self._flush_timer.stop()
             self._flush_timer = None
@@ -194,6 +197,17 @@ class ChatMessage(Static):
         if not self._pending_text:
             return
 
+        # Fast path: streaming message uses Static — direct string update, zero DOM cost.
+        # Avoids MarkdownStream's repeated remove/mount operations which trigger a full
+        # layout pass over every widget in the chat on every text chunk.
+        static = self.query_one_optional("#content", Static)
+        if static is not None and not isinstance(static, Markdown):
+            self._first_flush_done = True
+            static.update(self._content)
+            self._pending_text = ""
+            return
+
+        # Fallback: MarkdownStream path (history messages already have a Markdown widget).
         stream = self._get_stream()
         if not stream:
             # Widget not mounted yet - reschedule flush
@@ -202,8 +216,6 @@ class ChatMessage(Static):
             )
             return
 
-        # On first flush, write all content beyond what compose() rendered
-        # (handles race where append_content runs before compose)
         if not self._first_flush_done:
             self._first_flush_done = True
             text_to_write = self._content[len(self._initial_content) :]
@@ -215,13 +227,33 @@ class ChatMessage(Static):
         self._pending_text = ""
 
     def flush(self) -> None:
-        """Flush any pending text and stop the stream on completion."""
-        # Flush any remaining debounced text first
+        """Flush any pending text and finalise the message display."""
         self._flush_pending()
 
         if self._stream:
             self.call_later(self._stream.stop)
             self._stream = None
+
+        # If we were streaming into a Static, schedule a one-time swap to Markdown.
+        # This gives smooth streaming (zero DOM ops) then a single final render.
+        static = self.query_one_optional("#content", Static)
+        if static is not None and not isinstance(static, Markdown):
+            self.call_later(self._replace_static_with_markdown)
+
+    def _replace_static_with_markdown(self) -> None:
+        """Swap the streaming Static with a rendered Markdown widget (called once on flush)."""
+        static = self.query_one_optional("#content", Static)
+        if static is None or isinstance(static, Markdown):
+            return
+        content = self._content
+        if not content:
+            return
+        parent = static.parent
+        if parent is None:
+            return
+        # Remove Static then mount Markdown in its place (processed in queue order).
+        static.remove()
+        parent.mount(Markdown(content, id="content"))
 
     def get_raw_content(self) -> str:
         """Get raw content."""

--- a/claudechic/widgets/content/message.py
+++ b/claudechic/widgets/content/message.py
@@ -514,8 +514,10 @@ class ChatInput(TextArea):
         except Exception:
             return None
 
-    def on_paste(self, event) -> None:
+    async def on_paste(self, event) -> None:
         """Intercept paste - check for images BEFORE inserting text."""
+        import asyncio
+
         images = self._is_image_path(event.text)
         if images:
             # Deduplicate - terminals sometimes fire paste twice
@@ -534,7 +536,8 @@ class ChatInput(TextArea):
             event.stop()
             return
         # Fallback: raw clipboard image (e.g. Win+Shift+S screenshot)
-        clipboard_image = self._grab_clipboard_image()
+        # Run PIL in a thread — grabclipboard() blocks the event loop on Windows
+        clipboard_image = await asyncio.to_thread(self._grab_clipboard_image)
         if clipboard_image:
             now = time.time()
             if self._last_image_paste and now - self._last_image_paste[1] < 0.5:

--- a/claudechic/widgets/content/tools.py
+++ b/claudechic/widgets/content/tools.py
@@ -117,19 +117,18 @@ class ToolUseWidget(BaseToolWidget):
         if self.block.name == ToolName.SKILL and not self.block.input.get("args"):
             yield Static(self._header, classes="skill-header", markup=False)
             return
-        # ExitPlanMode: show plan as Markdown with special styling
+        # ExitPlanMode: show plan as plain text with lazy loading when collapsed
         if self.block.name == ToolName.EXIT_PLAN_MODE:
             self.add_class("exit-plan-mode")
-            plan_content = self._get_plan_content()
-            with QuietCollapsible(
-                title=self._header, collapsed=self._initial_collapsed
-            ):
-                if plan_content:
-                    yield Markdown(plan_content, id="plan-content")
-                else:
-                    yield Static("(Plan content not available)", id="tool-output")
-                if self._plan_path:
-                    yield Button("📋 Edit Plan", classes="edit-plan-btn")
+            if self._initial_collapsed:
+                yield QuietCollapsible(
+                    title=self._header,
+                    collapsed=True,
+                    content_factory=self._make_plan_content,
+                )
+            else:
+                with QuietCollapsible(title=self._header, collapsed=False):
+                    yield from self._make_plan_content()
             return
         # Edit tool: use lazy content when collapsed (DiffWidget is expensive)
         if self.block.name == ToolName.EDIT:
@@ -182,28 +181,39 @@ class ToolUseWidget(BaseToolWidget):
         # Use plan_path from agent (session-specific)
         if self._plan_path and self._plan_path.exists():
             try:
-                return self._plan_path.read_text()
+                return self._plan_path.read_text(encoding="utf-8")
             except Exception:
                 pass
 
         return None
 
-    def _try_update_plan_content(self, collapsible: QuietCollapsible) -> None:
-        """Try to update ExitPlanMode plan content if it wasn't available at compose time."""
-        try:
-            # Check if we have the placeholder - if plan-content exists, we're good
-            collapsible.query_one("#plan-content", Markdown)
-            return  # Already has Markdown content
-        except Exception:
-            pass  # No Markdown, check for tool-output placeholder
+    def _make_plan_content(self) -> list:
+        """Factory for lazy plan content creation (avoids rendering until expanded)."""
+        plan_content = self._get_plan_content()
+        items: list = []
+        if plan_content:
+            items.append(Static(plan_content, id="plan-content", markup=False))
+        else:
+            items.append(Static("(Plan content not available)", id="plan-placeholder"))
+        if self._plan_path:
+            items.append(Button("📋 Edit Plan", classes="edit-plan-btn"))
+        return items
 
-        # Try to get plan content now
+    def _try_update_plan_content(self, collapsible: QuietCollapsible) -> None:
+        """Try to update ExitPlanMode plan content if not available at compose time."""
+        try:
+            # Already has content — nothing to do
+            collapsible.query_one("#plan-content", Static)
+            return
+        except Exception:
+            pass
+
         plan_content = self._get_plan_content()
         if plan_content:
             try:
-                output_widget = collapsible.query_one("#tool-output", Static)
-                output_widget.remove()
-                collapsible.mount(Markdown(plan_content, id="plan-content"))
+                placeholder = collapsible.query_one("#plan-placeholder", Static)
+                placeholder.remove()
+                collapsible.mount(Static(plan_content, id="plan-content", markup=False))
             except Exception:
                 pass
 

--- a/claudechic/widgets/layout/chat_view.py
+++ b/claudechic/widgets/layout/chat_view.py
@@ -42,6 +42,13 @@ COLLAPSE_BY_DEFAULT = {
     ToolName.SKILL,
 }
 
+# MCP tool name prefixes to always collapse (noisy sandbox/utility tools)
+_COLLAPSE_PREFIXES = ("mcp__plugin_context-mode",)
+
+
+def _collapse_by_default(tool_name: str) -> bool:
+    return tool_name in COLLAPSE_BY_DEFAULT or tool_name.startswith(_COLLAPSE_PREFIXES)
+
 # How many recent tools to keep expanded (0 = collapse all)
 RECENT_TOOLS_EXPANDED = CONFIG.get("recent-tools-expanded", 2)
 
@@ -291,7 +298,7 @@ class ChatView(AutoHideScroll):
         from claude_agent_sdk import ToolUseBlock
 
         block = ToolUseBlock(id=tool.id, name=tool.name, input=tool.input)
-        should_collapse = collapsed or tool.name in COLLAPSE_BY_DEFAULT
+        should_collapse = collapsed or _collapse_by_default(tool.name)
         cwd = self._agent.cwd if self._agent else None
 
         if tool.name == ToolName.TASK:
@@ -408,7 +415,7 @@ class ChatView(AutoHideScroll):
                 old.collapse()
 
             # Create widget based on tool type
-            collapsed = RECENT_TOOLS_EXPANDED == 0 or tool.name in COLLAPSE_BY_DEFAULT
+            collapsed = RECENT_TOOLS_EXPANDED == 0 or _collapse_by_default(tool.name)
             cwd = self._agent.cwd if self._agent else None
             if tool.name == ToolName.TASK:
                 widget = TaskWidget(block, collapsed=collapsed, cwd=cwd)

--- a/claudechic/widgets/layout/chat_view.py
+++ b/claudechic/widgets/layout/chat_view.py
@@ -49,7 +49,7 @@ _DEFAULT_COLLAPSE_PREFIXES = [
     "mcp__searxng",
 ]
 _COLLAPSE_PREFIXES = tuple(
-    CONFIG.get("collapse-tool-prefixes", _DEFAULT_COLLAPSE_PREFIXES)
+    CONFIG.get("collapse-tool-prefixes") or _DEFAULT_COLLAPSE_PREFIXES
 )
 
 

--- a/claudechic/widgets/layout/chat_view.py
+++ b/claudechic/widgets/layout/chat_view.py
@@ -42,8 +42,15 @@ COLLAPSE_BY_DEFAULT = {
     ToolName.SKILL,
 }
 
-# MCP tool name prefixes to always collapse (noisy sandbox/utility tools)
-_COLLAPSE_PREFIXES = ("mcp__plugin_context-mode",)
+# MCP tool name prefixes to always collapse — configurable via
+# collapse-tool-prefixes in ~/.claude/.claudechic.yaml
+_DEFAULT_COLLAPSE_PREFIXES = [
+    "mcp__plugin_context-mode",
+    "mcp__searxng",
+]
+_COLLAPSE_PREFIXES = tuple(
+    CONFIG.get("collapse-tool-prefixes", _DEFAULT_COLLAPSE_PREFIXES)
+)
 
 
 def _collapse_by_default(tool_name: str) -> bool:

--- a/claudechic/widgets/layout/sidebar.py
+++ b/claudechic/widgets/layout/sidebar.py
@@ -98,19 +98,27 @@ class SessionItem(ListItem):
     SessionItem {
         pointer: pointer;
     }
+    SessionItem .session-last-msg {
+        color: $text-muted;
+        text-style: italic;
+    }
     """
 
     def __init__(
-        self, session_id: str, title: str, mtime: float, msg_count: int = 0
+        self, session_id: str, title: str, mtime: float, msg_count: int = 0, last_msg: str = ""
     ) -> None:
         super().__init__()
         self.session_id = session_id
         self.title = title
         self.mtime = mtime
         self.msg_count = msg_count
+        self.last_msg = last_msg
 
     def compose(self) -> ComposeResult:
         yield Label(self.title, classes="session-preview")
+        # Show last message as "where you left off" hint, if it differs from the title
+        if self.last_msg and self.last_msg.strip() != self.title.strip():
+            yield Label(self.last_msg[:80], classes="session-last-msg")
         time_ago = _format_time_ago(self.mtime)
         yield Label(f"{time_ago} · {self.msg_count} msgs", classes="session-meta")
 


### PR DESCRIPTION
## Problem

On Windows (and likely slow-git repos generally), every subagent spawned with `isolation: \"worktree\"` triggers `git worktree add` + `git worktree remove` — each taking 2–5 seconds on a large repo. This causes noticeable UI hangs every time an agent is created.

Additionally, `_populate_worktrees()` and the worktree autocomplete scan both call `git worktree list` on startup and on every autocomplete refresh, adding further overhead for users who don't use the `/worktree` workflow at all.

## Solution

Add a `worktree.enabled` flag to `~/.claude/.claudechic.yaml` (defaults `true`, preserving existing behaviour).

When set to `false`:
- `_populate_worktrees()` returns immediately — no git call on startup
- Worktree autocomplete scanning is skipped — no blocking `list_worktrees()` call
- `EnterWorktree` and `ExitWorktree` are added to `disallowed_tools` in `ClaudeAgentOptions` — subagents run locally in the current directory instead of creating isolated git worktrees

## Usage

```yaml
# ~/.claude/.claudechic.yaml
worktree:
  enabled: false  # set true to restore default behaviour
```

## Changes

- `claudechic/config.py` — adds `worktree.enabled` default
- `claudechic/app.py` — gates three worktree code paths on the config flag

No behaviour change for users who don't set the flag.