### PR TITLE
Add /effort command to control thinking depth

### DIFF
--- a/claudechic/agent.py
+++ b/claudechic/agent.py
@@ -184,6 +184,7 @@ class Agent:
         self.session_allowed_tools: set[str] = set()  # Tools allowed for this session
         self._pending_followup: str | None = None  # Auto-send after current response
         self.model: str | None = None  # Model override (None = SDK default)
+        self.effort: str | None = None  # Effort override (None = SDK default)
 
         # Worktree finish state (for /worktree finish flow)
         self.finish_state: FinishState | None = None

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -610,6 +610,7 @@ class ChatApp(App):
         resume: str | None = None,
         agent_name: str | None = None,
         model: str | None = None,
+        effort: str | None = None,
     ) -> ClaudeAgentOptions:
         """Create SDK options with common settings.
 
@@ -634,6 +635,7 @@ class ChatApp(App):
             cwd=cwd,
             resume=resume,
             model=model,
+            effort=effort,
             mcp_servers={"chic": create_chic_server(caller_name=agent_name)},
             include_partial_messages=True,
             stderr=self._handle_sdk_stderr,
@@ -771,7 +773,7 @@ class ChatApp(App):
 
         # Connect the agent to SDK
         options = self._make_options(
-            cwd=agent.cwd, resume=resume, agent_name=agent.name, model=agent.model
+            cwd=agent.cwd, resume=resume, agent_name=agent.name, model=agent.model, effort=agent.effort
         )
         try:
             await agent.connect(options, resume=resume)
@@ -1747,6 +1749,7 @@ class ChatApp(App):
                     resume=resume_id,
                     agent_name=agent.name,
                     model=agent.model,
+                    effort=agent.effort,
                 )
             )
 
@@ -1928,7 +1931,7 @@ class ChatApp(App):
         """Disconnect and reconnect an agent to reload its session."""
         await agent.disconnect()
         options = self._make_options(
-            cwd=agent.cwd, resume=session_id, agent_name=agent.name, model=agent.model
+            cwd=agent.cwd, resume=session_id, agent_name=agent.name, model=agent.model, effort=agent.effort
         )
         await agent.connect(options, resume=session_id)
 
@@ -1943,7 +1946,7 @@ class ChatApp(App):
             chat_view.clear()
         await agent.disconnect()
         options = self._make_options(
-            cwd=agent.cwd, agent_name=agent.name, model=agent.model
+            cwd=agent.cwd, agent_name=agent.name, model=agent.model, effort=agent.effort
         )
         await agent.connect(options)
         self.refresh_context()
@@ -1975,6 +1978,11 @@ class ChatApp(App):
             return
         old_model = agent.model or "default"
         agent.model = model
+        # Haiku doesn't support extended thinking — clear effort if switching to it
+        if model == "haiku" and agent.effort:
+            agent.effort = ""
+            self.status_footer.effort = ""
+            self.notify("Effort cleared (haiku does not support extended thinking)")
         self.run_worker(
             capture(
                 "model_changed",
@@ -1989,6 +1997,28 @@ class ChatApp(App):
             await agent.disconnect()
             options = self._make_options(
                 cwd=agent.cwd, agent_name=agent.name, model=model
+            )
+            await agent.connect(options)
+
+    @work(group="effort_switch", exclusive=True, exit_on_error=False)
+    async def _set_agent_effort(self, effort: str) -> None:
+        """Set effort level for active agent and reconnect."""
+        agent = self._agent
+        if not agent:
+            self.notify("No active agent", severity="warning")
+            return
+        if agent.model == "haiku":
+            self.notify("Haiku does not support extended thinking", severity="error")
+            return
+        if effort == agent.effort:
+            return
+        agent.effort = effort
+        self.status_footer.effort = effort
+        if agent.client:
+            self.notify(f"Setting effort to {effort}...")
+            await agent.disconnect()
+            options = self._make_options(
+                cwd=agent.cwd, agent_name=agent.name, model=agent.model, effort=effort
             )
             await agent.connect(options)
 
@@ -2126,7 +2156,7 @@ class ChatApp(App):
             # Reconnect with fresh session (like /clear)
             await agent.disconnect()
             options = self._make_options(
-                cwd=agent.cwd, agent_name=agent.name, model=agent.model
+                cwd=agent.cwd, agent_name=agent.name, model=agent.model, effort=agent.effort
             )
             await agent.connect(options)
 
@@ -2226,6 +2256,15 @@ class ChatApp(App):
                 self._attach_image(path)
             event.prevent_default()
             event.stop()
+            return
+
+        # Empty paste may mean clipboard holds image data rather than text
+        if not event.text.strip():
+            path = self._chat_input._get_clipboard_image()
+            if path:
+                self._attach_image(path)
+                event.prevent_default()
+                event.stop()
 
     def on_key(self, event) -> None:
         if self.query(SelectionPrompt) or self.query(QuestionPrompt):
@@ -2351,6 +2390,7 @@ class ChatApp(App):
 
         # Update footer
         self.status_footer.permission_mode = new_agent.permission_mode
+        self.status_footer.effort = new_agent.effort or ""
         self._update_footer_model(new_agent.model)
 
         # Update todo panel and context

--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -94,6 +94,7 @@ COMMANDS: list[tuple[str, str, list[str]]] = [
     ("/compactish", "Compact session to reduce context", []),
     ("/usage", "Show API rate limit usage", []),
     ("/model", "Change model", []),
+    ("/effort", "Set thinking effort level", []),
     ("/vim", "Toggle vi mode for input", []),
     ("/processes", "Show background processes", []),
     ("/reviews", "Show roborev reviews", []),
@@ -147,6 +148,8 @@ def get_help_commands() -> list[tuple[str, str]]:
             display_name = "/plan-swarm"
         elif name == "/rewind":
             display_name = "/rewind [index]"
+        elif name == "/effort":
+            display_name = "/effort [low|medium|high|xhigh|max]"
         result.append((display_name, desc))
     return result
 
@@ -230,6 +233,26 @@ def handle_command(app: "ChatApp", prompt: str) -> bool:
                 )
             else:
                 app._set_agent_model(model)
+        return True
+
+    if cmd == "/effort" or cmd.startswith("/effort "):
+        _track_command(app, "effort")
+        parts = cmd.split(maxsplit=1)
+        if len(parts) == 1:
+            # No argument - show current effort
+            agent = app._agent
+            current = agent.effort if agent else None
+            app.notify(f"Current effort: {current or 'default'}")
+        else:
+            effort = parts[1].lower()
+            valid_efforts = {"low", "medium", "high", "xhigh", "max"}
+            if effort not in valid_efforts:
+                app.notify(
+                    f"Invalid effort '{effort}'. Use: low, medium, high, xhigh, max",
+                    severity="error",
+                )
+            else:
+                app._set_agent_effort(effort)
         return True
 
     if cmd == "/exit":

--- a/claudechic/widgets/layout/footer.py
+++ b/claudechic/widgets/layout/footer.py
@@ -98,6 +98,7 @@ class StatusFooter(Static):
     can_focus = False
     permission_mode = reactive("default")  # default, acceptEdits, plan
     model = reactive("")
+    effort = reactive("")
     branch = reactive("")
 
     async def on_mount(self) -> None:
@@ -126,10 +127,21 @@ class StatusFooter(Static):
         if label := self.query_one_optional("#branch-label", Static):
             label.update(f"⎇ {value}" if value else "")
 
+    def _render_model_label(self) -> None:
+        """Update model label combining model and effort."""
+        if label := self.query_one_optional("#model-label", ModelLabel):
+            text = self.model
+            if self.effort:
+                text = f"{text} · {self.effort}" if text else self.effort
+            label.update(text)
+
     def watch_model(self, value: str) -> None:
         """Update model label when model changes."""
-        if label := self.query_one_optional("#model-label", ModelLabel):
-            label.update(value if value else "")
+        self._render_model_label()
+
+    def watch_effort(self, value: str) -> None:
+        """Update model label when effort changes."""
+        self._render_model_label()
 
     def watch_permission_mode(self, value: str) -> None:
         """Update permission mode label when setting changes."""


### PR DESCRIPTION
## Summary

- Adds a `/effort [low|medium|high|xhigh|max]` slash command to set the thinking effort level for the active agent, wiring into `ClaudeAgentOptions.effort` in the SDK
- Displays the current effort alongside the model name in the footer (e.g. `Opus 4.7 · high`)
- Running `/effort` with no argument shows the current level as a notification
- Guards against setting effort on haiku (which doesn't support extended thinking), and automatically clears effort when switching to haiku from a thinking-capable model

## Changes

- **`agent.py`** — add `effort: str | None` field to `Agent`
- **`commands.py`** — add `/effort` to command list, help display, and command handler
- **`app.py`** — add `_set_agent_effort()`, pass `effort` through all `_make_options()` call sites, clear effort on switch to haiku
- **`footer.py`** — add `effort` reactive to `StatusFooter`; render as `"{model} · {effort}"` when set

## Test plan

- [ ] `/effort high` on opus/sonnet reconnects and passes `--effort high` to CLI
- [ ] Footer shows `Opus 4.7 · high` after setting effort
- [ ] `/effort` with no argument shows current level notification
- [ ] `/effort` on haiku shows error notification and does not reconnect
- [ ] `/model haiku` when effort is set clears effort and notifies
- [ ] Switching between agents shows each agent's effort independently in footer
- [ ] Invalid value (e.g. `/effort extreme`) shows error notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)