### PR TITLE
Strip \r from PTY shell output so lines don't overwrite each other

### DIFF
--- a/claudechic/shell_runner.py
+++ b/claudechic/shell_runner.py
@@ -75,7 +75,10 @@ def run_in_pty(
 
         os.close(master_fd)
         proc.wait()
-        return output.decode(errors="replace"), proc.returncode or 0
+        # Strip \r from PTY output (onlcr maps \n to \r\n); Rich's from_ansi
+        # treats bare \r as a cursor-return and collapses lines.
+        decoded = output.decode(errors="replace").replace("\r", "")
+        return decoded, proc.returncode or 0
     except Exception:
         os.close(master_fd)
         raise
@@ -162,7 +165,8 @@ def _run_in_pty_with_cancel(
         os.close(master_fd)
         master_fd = -1
         proc.wait()
-        return output.decode(errors="replace"), proc.returncode or 0, was_cancelled
+        decoded = output.decode(errors="replace").replace("\r", "")
+        return decoded, proc.returncode or 0, was_cancelled
 
     except Exception:
         if slave_fd >= 0:

--- a/claudechic/widgets/content/tools.py
+++ b/claudechic/widgets/content/tools.py
@@ -417,6 +417,9 @@ class ShellOutputWidget(Static):
         with QuietCollapsible(title=title, collapsed=self._collapsed):
             # Combine stderr + stdout, parse ANSI color codes
             output = "\n".join(filter(None, [self.stderr, self.stdout])).rstrip()
+            # PTY onlcr mode emits \r\n; strip \r so Rich doesn't treat it
+            # as a carriage return (which collapses lines onto each other).
+            output = output.replace("\r\n", "\n").replace("\r", "")
             if output:
                 yield Static(Text.from_ansi(output), id="shell-output")
 

--- a/claudechic/widgets/content/tools.py
+++ b/claudechic/widgets/content/tools.py
@@ -417,9 +417,6 @@ class ShellOutputWidget(Static):
         with QuietCollapsible(title=title, collapsed=self._collapsed):
             # Combine stderr + stdout, parse ANSI color codes
             output = "\n".join(filter(None, [self.stderr, self.stdout])).rstrip()
-            # PTY onlcr mode emits \r\n; strip \r so Rich doesn't treat it
-            # as a carriage return (which collapses lines onto each other).
-            output = output.replace("\r\n", "\n").replace("\r", "")
             if output:
                 yield Static(Text.from_ansi(output), id="shell-output")
 


### PR DESCRIPTION
## Summary

`ShellOutputWidget` runs `!` commands through a PTY, which emits `\r\n` line endings by default (`onlcr` termios mode). When that output was passed to `Text.from_ansi`, Rich interpreted each `\r` as a carriage return — collapsing every line onto the same row, so only the last line of output was visible. The widget would render with a large blank area where the earlier lines should have been.

Stripping `\r` before rendering fixes the issue. Color/style codes still render normally; only the bare CRs are removed.

## Test plan

- [x] `! echo -e "one\ntwo\nthree"` — all three lines render
- [x] `! ls -la` — full directory listing renders, not just the final entry
- [x] `! git status` — multi-line output displays correctly
- [x] Colored output (e.g. `! ls --color=always`) still renders ANSI colors

## Before / after

Before: only the last line of output was visible, with blank space above it.
After: full output renders correctly.