### PR TITLE
Fix crash when cycling to Auto mode on non-Opus models

### DIFF
--- a/claudechic/agent.py
+++ b/claudechic/agent.py
@@ -127,6 +127,20 @@ _SDK_PERMISSION_MODES = frozenset(
 _UI_PERMISSION_MODES = frozenset({"default", "acceptEdits", "plan", "auto"})
 
 
+def model_supports_auto_mode(model: str | None) -> bool:
+    """Return True if the model supports the "auto" permission mode.
+
+    The CLI restricts "auto" (a model classifier that approves/denies tool
+    calls) to Opus. Sonnet, Haiku, and other models reject the mode with
+    "this model does not have Auto mode". `None` means SDK default — we
+    can't tell what it'll resolve to, so be permissive and let the SDK
+    reject it if appropriate.
+    """
+    if model is None:
+        return True
+    return "opus" in model.lower()
+
+
 def get_default_permission_mode(cwd: Path) -> PermissionMode:
     """Resolve ``permissions.defaultMode`` from Claude settings.json layers.
 
@@ -1032,23 +1046,40 @@ Key Rules:
 
         Args:
             mode: One of 'default', 'acceptEdits', 'plan', 'auto'
+
+        Raises:
+            ValueError: If the SDK rejects the mode (e.g. "auto" on a
+                non-Opus model). The agent's prior mode is restored before
+                raising so the UI state stays consistent.
         """
         assert mode in _UI_PERMISSION_MODES, f"Invalid permission mode: {mode}"
-        if self.permission_mode != mode:
-            self.permission_mode = mode
-            # Fetch plan path when entering plan mode
-            if mode == "plan":
-                await self.ensure_plan_path()
-            # Push mode to SDK as soon as the subprocess is connected.
-            # Do NOT gate on self.session_id: the control request works before
-            # the `init` SystemMessage arrives, and gating on session_id caused
-            # shift-tab into plan mode right after launch to silently no-op
-            # the SDK call — the CLI would then reject ExitPlanMode at
-            # validateInput with "you are not in plan mode".
-            if self.client:
+        if self.permission_mode == mode:
+            return
+        previous_mode = self.permission_mode
+        self.permission_mode = mode
+        # Fetch plan path when entering plan mode
+        if mode == "plan":
+            await self.ensure_plan_path()
+        # Push mode to SDK as soon as the subprocess is connected.
+        # Do NOT gate on self.session_id: the control request works before
+        # the `init` SystemMessage arrives, and gating on session_id caused
+        # shift-tab into plan mode right after launch to silently no-op
+        # the SDK call — the CLI would then reject ExitPlanMode at
+        # validateInput with "you are not in plan mode".
+        if self.client:
+            try:
                 await self.client.set_permission_mode(cast(PermissionMode, mode))
-            if self.observer:
-                self.observer.on_permission_mode_changed(self)
+            except Exception as e:
+                # SDK/CLI rejected the mode (e.g. "auto" on a non-Opus
+                # model). Roll back so the UI doesn't show a mode the CLI
+                # isn't actually in, then surface a typed error so the
+                # caller can render a friendly message.
+                self.permission_mode = previous_mode
+                if self.observer:
+                    self.observer.on_permission_mode_changed(self)
+                raise ValueError(str(e)) from e
+        if self.observer:
+            self.observer.on_permission_mode_changed(self)
 
     def _build_message_with_images(self, prompt: str) -> dict[str, Any]:
         """Build SDK message with text and images."""

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -57,6 +57,7 @@ from claudechic.agent import (
     ImageAttachment,
     ToolUse,
     get_default_permission_mode,
+    model_supports_auto_mode,
 )
 from claudechic.agent_manager import AgentManager
 from claudechic.analytics import capture
@@ -520,17 +521,39 @@ class ChatApp(App):
                 self.input_container.remove_class("hidden")
 
     def action_cycle_permission_mode(self) -> None:
-        """Cycle permission mode: default -> acceptEdits -> plan -> auto -> default."""
+        """Cycle permission mode: default -> acceptEdits -> plan -> auto -> default.
+
+        Skips "auto" when the active model doesn't support it (auto is
+        Opus-only — the CLI rejects it on Sonnet/Haiku with "this model
+        does not have Auto mode" and the unhandled exception used to
+        crash the app).
+        """
         if self._agent:
             agent = self._agent  # Capture for closure
             modes = ["default", "acceptEdits", "plan", "auto"]
             current = agent.permission_mode
-            next_idx = (modes.index(current) + 1) % len(modes)
+            # If we're sitting in a non-UI mode (bypassPermissions, dontAsk),
+            # treat "default" as the cursor so we still advance somewhere sane.
+            try:
+                cursor = modes.index(current)
+            except ValueError:
+                cursor = 0
+            next_idx = (cursor + 1) % len(modes)
             next_mode = modes[next_idx]
+            if next_mode == "auto" and not model_supports_auto_mode(agent.model):
+                # Skip "auto"; wrap to "default".
+                next_mode = "default"
 
-            # Schedule the async call
+            # Schedule the async call. Defensive catch handles the residual
+            # case where set_permission_mode is rejected by the SDK
+            # despite our pre-check (e.g. model metadata is unexpected).
             async def set_mode():
-                await agent.set_permission_mode(next_mode)
+                try:
+                    await agent.set_permission_mode(next_mode)
+                except ValueError as e:
+                    self.notify(
+                        f"Cannot set {next_mode} mode: {e}", severity="warning"
+                    )
 
             self.run_worker(set_mode(), exclusive=False)
 
@@ -2041,6 +2064,21 @@ class ChatApp(App):
             return
         old_model = agent.model or "default"
         agent.model = model
+        # Auto mode is Opus-only. If the user switches Opus -> Sonnet/Haiku
+        # while currently in Auto, the CLI will reject it on the next
+        # control_request — pre-emptively drop the agent back to acceptEdits
+        # so the UI stays in sync and the user gets a clear notice.
+        if (
+            agent.permission_mode == "auto"
+            and not model_supports_auto_mode(model)
+        ):
+            agent.permission_mode = "acceptEdits"
+            if agent.observer:
+                agent.observer.on_permission_mode_changed(agent)
+            self.notify(
+                "Auto mode requires Opus — reverted to Auto-edit.",
+                severity="warning",
+            )
         self.run_worker(
             capture(
                 "model_changed",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from claude_agent_sdk import PermissionResultAllow
 
-from claudechic.agent import Agent, get_default_permission_mode, to_ui_permission_mode
+from claudechic.agent import (
+    Agent,
+    get_default_permission_mode,
+    model_supports_auto_mode,
+    to_ui_permission_mode,
+)
 
 
 def _write_settings(path: Path, default_mode: str) -> None:
@@ -68,6 +73,48 @@ def test_to_ui_permission_mode_collapses_sdk_only_modes():
 def test_to_ui_permission_mode_passes_ui_modes_through():
     for mode in ("default", "acceptEdits", "plan", "auto"):
         assert to_ui_permission_mode(mode) == mode
+
+
+def test_model_supports_auto_mode_opus():
+    """Auto mode is Opus-only."""
+    assert model_supports_auto_mode("opus") is True
+    assert model_supports_auto_mode("claude-opus-4-7") is True
+    assert model_supports_auto_mode("Opus") is True
+
+
+def test_model_supports_auto_mode_non_opus():
+    """Sonnet, Haiku, and other models do not support auto mode."""
+    assert model_supports_auto_mode("sonnet") is False
+    assert model_supports_auto_mode("haiku") is False
+    assert model_supports_auto_mode("claude-sonnet-4-7") is False
+
+
+def test_model_supports_auto_mode_none_is_permissive():
+    """None means SDK default — let the SDK decide. Be permissive."""
+    assert model_supports_auto_mode(None) is True
+
+
+@pytest.mark.asyncio
+async def test_set_permission_mode_rolls_back_on_sdk_error(tmp_path):
+    """If the CLI rejects "auto" (e.g. on Sonnet), the agent rolls back
+    to its prior mode and raises ValueError so the caller can render a
+    friendly message instead of crashing."""
+    agent = Agent(name="t", cwd=tmp_path, permission_mode="plan")
+    mock_client = MagicMock()
+    mock_client.set_permission_mode = AsyncMock(
+        side_effect=Exception("this model does not have Auto mode")
+    )
+    agent.client = mock_client
+    observer = MagicMock()
+    agent.observer = observer
+
+    with pytest.raises(ValueError, match="Auto mode"):
+        await agent.set_permission_mode("auto")
+
+    # Mode rolled back to the prior value, not stuck on "auto".
+    assert agent.permission_mode == "plan"
+    # Observer was notified of the rollback so the footer re-syncs.
+    observer.on_permission_mode_changed.assert_called_with(agent)
 
 
 @pytest.mark.asyncio

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -55,6 +55,46 @@ async def test_permission_mode_cycle(mock_sdk):
 
 
 @pytest.mark.asyncio
+async def test_permission_mode_cycle_skips_auto_on_sonnet(mock_sdk):
+    """On non-Opus models, Shift+Tab wraps default -> acceptEdits -> plan -> default.
+
+    Regression: cycling onto "auto" on Sonnet/Haiku used to crash the app
+    because the CLI rejects auto mode for non-Opus models with
+    "this model does not have Auto mode".
+    """
+    app = ChatApp()
+    async with app.run_test() as pilot:
+        assert app._agent is not None
+        # Pin the agent to Sonnet so the cycler should skip "auto".
+        app._agent.model = "sonnet"
+        assert app._agent.permission_mode == "default"
+
+        await pilot.press("shift+tab")
+        assert app._agent.permission_mode == "acceptEdits"
+
+        await pilot.press("shift+tab")
+        assert app._agent.permission_mode == "plan"
+
+        # On Sonnet, the next step skips "auto" and wraps to "default".
+        await pilot.press("shift+tab")
+        assert app._agent.permission_mode == "default"
+
+
+@pytest.mark.asyncio
+async def test_permission_mode_cycle_lands_on_auto_for_opus(mock_sdk):
+    """On Opus, the cycler still includes "auto" as the fourth step."""
+    app = ChatApp()
+    async with app.run_test() as pilot:
+        assert app._agent is not None
+        app._agent.model = "opus"
+
+        await pilot.press("shift+tab")
+        await pilot.press("shift+tab")
+        await pilot.press("shift+tab")
+        assert app._agent.permission_mode == "auto"
+
+
+@pytest.mark.asyncio
 async def test_permission_mode_footer_updates(mock_sdk):
     """Footer reflects permission mode state."""
     app = ChatApp()


### PR DESCRIPTION
## Summary
- Shift+Tab cycler now skips Auto on non-Opus models
- `set_permission_mode` catches "this model does not have Auto mode" and surfaces an inline message instead of crashing the app
- Switching from Opus -> Sonnet while in Auto auto-reverts to acceptEdits with a notice

## Test plan
- [x] `uv run pytest` (added tests for skip behavior + defensive catch)
- [ ] Manual: launch on Sonnet, Shift+Tab cycle wraps default -> acceptEdits -> plan -> default (no Auto crash)
- [ ] Manual: launch on Opus, set Auto, switch to Sonnet — mode reverts cleanly with footer message

Generated with [Claude Code](https://claude.com/claude-code)