### PR TITLE
fix: clipboard robustness improvements

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -276,6 +276,10 @@ class ChatApp(App):
         # Track pending slash commands passed to Claude (for typo detection)
         # agent_id -> command name (e.g., "/cleanup")
         self._pending_slash_commands: dict[str, str] = {}
+        # Clipboard robustness
+        self._osc52_cached: bool | None = None
+        self._copy_timer: Timer | None = None
+        self._copy_failed_notified: bool = False
 
     def _fatal_error(self) -> None:
         """Override to use plain Python tracebacks instead of rich's fancy ones."""
@@ -1547,11 +1551,80 @@ class ChatApp(App):
         if chat_view:
             chat_view.clear()
 
+    def _safe_get_selected_text(self) -> str | None:
+        """Get selected text, returning None on stale selection coordinates."""
+        try:
+            return self.screen.get_selected_text()
+        except IndexError:
+            return None
+
+    def _osc52_likely_works(self) -> bool:
+        """Check whether OSC 52 clipboard can reach the terminal. Cached."""
+        if self._osc52_cached is not None:
+            return self._osc52_cached
+        import os
+        import subprocess
+
+        if not os.environ.get("TMUX"):
+            self._osc52_cached = True
+            return True
+        try:
+            result = subprocess.run(
+                ["tmux", "show", "-gv", "set-clipboard"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            self._osc52_cached = result.stdout.strip().lower() != "off"
+        except Exception:
+            self._osc52_cached = True
+        return self._osc52_cached
+
+    def _try_copy(self, text: str) -> bool:
+        """Copy text to clipboard, returning True if we believe it succeeded."""
+        import shutil
+        import subprocess
+
+        self.copy_to_clipboard(text)  # OSC 52 + upstream PRIMARY override
+        if not sys.platform.startswith("linux"):
+            return True
+        for cmd in (
+            ["xclip", "-selection", "clipboard"],
+            ["xsel", "--clipboard", "--input"],
+        ):
+            if shutil.which(cmd[0]):
+                try:
+                    proc = subprocess.Popen(
+                        cmd,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    proc.stdin.write(text.encode())  # type: ignore[union-attr]
+                    proc.stdin.close()  # type: ignore[union-attr]
+                    proc.wait(timeout=2)
+                    if proc.returncode == 0:
+                        return True
+                    continue  # non-zero exit (e.g., no DISPLAY), try next tool
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                    continue
+                except Exception:
+                    continue
+        return self._osc52_likely_works()
+
     def action_copy_selection(self) -> None:
-        selected = self.screen.get_selected_text()
+        selected = self._safe_get_selected_text()
         if selected:
-            self.copy_to_clipboard(selected)
-            self.notify("Copied to clipboard")
+            if self._try_copy(selected):
+                self._copy_failed_notified = False  # reset on success
+                self.notify("Copied to clipboard")
+            elif not self._copy_failed_notified:
+                self._copy_failed_notified = True
+                self.notify(
+                    "Copy failed — clipboard tool not found", severity="warning"
+                )
 
     def action_new_agent(self) -> None:
         """Create a new agent (prompts for name/path)."""
@@ -1635,10 +1708,20 @@ class ChatApp(App):
                 return
 
     def _check_and_copy_selection(self) -> None:
-        selected = self.screen.get_selected_text()
+        selected = self._safe_get_selected_text()
         if selected and len(selected.strip()) > 0:
-            self.copy_to_clipboard(selected)
-            self.notify("Copied", timeout=1)
+            if self._try_copy(selected):
+                self._copy_failed_notified = False  # reset on success
+                if self._copy_timer is not None:
+                    self._copy_timer.stop()
+                self._copy_timer = self.set_timer(
+                    0.5, lambda: self.notify("Copied", timeout=1)
+                )
+            elif not self._copy_failed_notified:
+                self._copy_failed_notified = True
+                self.notify(
+                    "Copy failed — clipboard tool not found", severity="warning"
+                )
 
     def action_quit(self) -> None:  # type: ignore[override]
         # If history search is visible, cancel it

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -1,6 +1,6 @@
 """App-level UI tests without SDK dependency."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -867,3 +867,39 @@ async def test_stop_review_polling_unconditional(mock_sdk):
         fake_timer.stop.assert_called_once()
         assert app._review_poll_timer is None
         assert app._review_poll_agent_id is None
+
+
+# =============================================================================
+# Clipboard robustness (P2)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_safe_get_selected_text_handles_index_error(mock_sdk):
+    """_safe_get_selected_text should return None on IndexError, not crash."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        with patch.object(app.screen, "get_selected_text", side_effect=IndexError("stale")):
+            result = app._safe_get_selected_text()
+            assert result is None
+
+
+@pytest.mark.asyncio
+async def test_try_copy_returns_bool(mock_sdk):
+    """_try_copy should return True on success."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        result = app._try_copy("test")
+        assert isinstance(result, bool)
+
+
+@pytest.mark.asyncio
+async def test_try_copy_returns_false_when_no_tools(mock_sdk):
+    """_try_copy should return False when no clipboard tools and OSC 52 off."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        with patch("shutil.which", return_value=None), \
+             patch.object(app, "_osc52_likely_works", return_value=False), \
+             patch("sys.platform", "linux"):
+            result = app._try_copy("test")
+            assert result is False


### PR DESCRIPTION
## Why

Copy-to-clipboard was silently failing in common environments — inside tmux with `set-clipboard off`, on headless Linux without xclip, or when a stale text selection triggered an `IndexError` crash. Users would hit Ctrl+C or click "Copy" and get no feedback, or worse, a traceback. This PR makes copy actually work across environments and tells you when it can't.

## Summary
- Add `_try_copy()` wrapper returning bool for success/failure detection
- `_safe_get_selected_text()` catches `IndexError` on stale selections
- `_osc52_likely_works()` detects tmux with `set-clipboard off` (cached)
- Use CLIPBOARD selection (Ctrl+V) instead of PRIMARY (middle-click)
- Copy timer dedup prevents duplicate "Copied" toasts
- "Copy failed" notification throttled, resets on success

## Changes
- `claudechic/app.py` — new clipboard helpers + rewired copy actions (+95/−7)
- `tests/test_app_ui.py` — tests for the new clipboard paths (+38)