### PR TITLE
feat: ErrorMessage click-to-dismiss

### DIFF
--- a/claudechic/styles.tcss
+++ b/claudechic/styles.tcss
@@ -134,6 +134,10 @@ ErrorMessage {
     margin: 1 0 1 0;
 }
 
+ErrorMessage:hover {
+    background: $error 20%;
+}
+
 /* System info messages - muted, informational */
 SystemInfo {
     border-left: thick $panel;

--- a/claudechic/widgets/content/message.py
+++ b/claudechic/widgets/content/message.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.events import Click
 from textual.message import Message
 from textual.widgets import Markdown, TextArea, Static
 
@@ -88,7 +89,18 @@ class ErrorMessage(Static):
         display = f"**Error:** {self._message}"
         if self._exception:
             display += f"\n\n`{type(self._exception).__name__}: {self._exception}`"
+        display += "\n\n*click to dismiss*"
         yield Markdown(display, id="content")
+
+    def on_click(self, event: Click) -> None:
+        """Dismiss on left-click."""
+        if event.button != 1:
+            return
+        if not self.is_attached:
+            return
+        event.stop()
+        self.display = False
+        self.remove()
 
 
 class SystemInfo(Static):


### PR DESCRIPTION
## Why

Error messages in the chat were permanent — once displayed, they stayed forever, cluttering the conversation and adding noise. Now you can just click them away.

## Summary
- ErrorMessage widgets are dismissable with a single left-click
- Hover state highlights the error to signal interactivity
- "click to dismiss" hint added to error display

## Changes
- `claudechic/widgets/content/message.py` — add `on_click` handler + dismiss hint (+12)
- `claudechic/styles.tcss` — hover background style for ErrorMessage (+4)