### PR TITLE
fix: preserve session when switching model or effort

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -2157,12 +2157,14 @@ class ChatApp(App):
         self._update_footer_model(model)
         if agent.client:
             self.notify(f"Switching to {model}...")
+            session_id = agent.session_id
             await agent.disconnect()
             options = self._make_options(
                 cwd=agent.cwd,
                 agent_name=agent.name,
                 model=model,
                 effort=agent.effort,
+                resume=session_id,
             )
             await agent.connect(options)
 
@@ -2199,11 +2201,12 @@ class ChatApp(App):
         if not agent:
             self.notify("No active agent", severity="warning")
             return
-        if effort == agent.effort:
+        effective = None if effort == "default" else effort
+        if effective == agent.effort:
             return
         old_effort = agent.effort or "default"
-        agent.effort = effort
-        self.status_footer.effort = effort or ""
+        agent.effort = effective
+        self.status_footer.effort = effective or ""
         self.run_worker(
             capture(
                 "effort_changed",
@@ -2213,13 +2216,16 @@ class ChatApp(App):
             )
         )
         if agent.client:
-            self.notify(f"Switching effort to {effort}...")
+            label = effort if effort != "default" else "auto"
+            self.notify(f"Switching effort to {label}...")
+            session_id = agent.session_id
             await agent.disconnect()
             options = self._make_options(
                 cwd=agent.cwd,
                 agent_name=agent.name,
                 model=agent.model,
-                effort=effort,
+                effort=agent.effort,
+                resume=session_id,
             )
             await agent.connect(options)
 

--- a/claudechic/widgets/prompts.py
+++ b/claudechic/widgets/prompts.py
@@ -439,6 +439,7 @@ class EffortPrompt(BasePrompt):
     # Source of truth for supported effort levels. Used by `/effort <level>`
     # validation in commands.py — keep in sync if we add values.
     OPTIONS: tuple[tuple[str, str], ...] = (
+        ("default", "SDK default (reset to auto)"),
         ("low", "Fewer tool calls, terse output"),
         ("medium", "Balanced"),
         ("high", "Deeper reasoning (often the sweet spot)"),

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -1,6 +1,6 @@
 """App-level UI tests without SDK dependency."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -867,3 +867,45 @@ async def test_stop_review_polling_unconditional(mock_sdk):
         fake_timer.stop.assert_called_once()
         assert app._review_poll_timer is None
         assert app._review_poll_agent_id is None
+
+
+@pytest.mark.asyncio
+async def test_model_switch_preserves_session(mock_sdk):
+    """Switching model should pass resume=session_id to preserve conversation."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        agent = app._agent
+        if not agent:
+            pytest.skip("No agent available")
+        agent.session_id = "test-session-123"
+        with patch.object(app, "_make_options") as mock_opts, \
+             patch.object(agent, "disconnect", new_callable=AsyncMock), \
+             patch.object(agent, "connect", new_callable=AsyncMock):
+            mock_opts.return_value = MagicMock()
+            app._set_agent_model("opus")
+            await wait_for_workers(app)
+            mock_opts.assert_called_once()
+            _, kwargs = mock_opts.call_args
+            assert kwargs["resume"] == "test-session-123"
+
+
+@pytest.mark.asyncio
+async def test_effort_default_maps_to_none(mock_sdk):
+    """effort='default' should pass effort=None to _make_options (SDK auto)."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        agent = app._agent
+        if not agent:
+            pytest.skip("No agent available")
+        agent.session_id = "test-session-456"
+        agent.effort = "high"
+        with patch.object(app, "_make_options") as mock_opts, \
+             patch.object(agent, "disconnect", new_callable=AsyncMock), \
+             patch.object(agent, "connect", new_callable=AsyncMock):
+            mock_opts.return_value = MagicMock()
+            app._set_agent_effort("default")
+            await wait_for_workers(app)
+            mock_opts.assert_called_once()
+            _, kwargs = mock_opts.call_args
+            assert kwargs["effort"] is None, "default should map to None"
+            assert kwargs["resume"] == "test-session-456"

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -244,10 +244,10 @@ async def test_effort_prompt_selection():
     app = WidgetTestApp(lambda: EffortPrompt(current_value="medium"))
     async with app.run_test() as pilot:
         prompt = app.query_one(EffortPrompt)
-        # medium is index 1
-        assert prompt.selected_idx == 1
-        # Navigate to high (index 2) and select via number key
-        await pilot.press("3")
+        # medium is index 2 (after "default" at 0, "low" at 1)
+        assert prompt.selected_idx == 2
+        # Navigate to high (index 3) and select via number key
+        await pilot.press("4")
         result = await prompt.wait()
     assert result == "high"
 
@@ -262,8 +262,8 @@ async def test_effort_prompt_xhigh_initial():
     app = WidgetTestApp(lambda: EffortPrompt(current_value="xhigh"))
     async with app.run_test():
         prompt = app.query_one(EffortPrompt)
-        # xhigh is the 4th option (index 3)
-        assert prompt.selected_idx == 3
+        # xhigh is the 5th option (index 4, after "default" at 0)
+        assert prompt.selected_idx == 4
         assert prompt.OPTIONS[prompt.selected_idx][0] == "xhigh"
 
 


### PR DESCRIPTION
## Why

Switching model or effort level mid-conversation was destroying the session, the agent disconnected and reconnected fresh, losing all context. Now the session ID is captured before disconnect and passed as `resume`, so conversation continues seamlessly after the switch.

## Summary
- Capture `session_id` before disconnect, pass `resume=session_id` to reconnect
- Map effort "default" to `None` (SDK auto) instead of literal string
- Add "default" option to EffortPrompt for resetting effort level

## Changes
- `claudechic/app.py` — preserve session on model/effort switch (+10/−5)
- `claudechic/widgets/prompts.py` — add "default" effort option (+1)
- `tests/test_app_ui.py` — tests for session preservation + default mapping (+43/−1)
- `tests/test_widgets.py` — update EffortPrompt index assertions (+6/−6)