### PR TITLE
feat: --width CLI argument for terminal width control

### DIFF
--- a/claudechic/__main__.py
+++ b/claudechic/__main__.py
@@ -62,7 +62,7 @@ def main():
         "-w",
         type=positive_int,
         default=None,
-        help="Set terminal width for chat column",
+        help="Max width (in cells) for the chat column (default: 100)",
     )
     parser.add_argument("prompt", nargs="*", help="Initial prompt to send")
     args = parser.parse_args()

--- a/claudechic/__main__.py
+++ b/claudechic/__main__.py
@@ -12,6 +12,17 @@ from claudechic.errors import setup_logging
 setup_logging()
 
 
+def positive_int(value: str) -> int:
+    """Argparse type for positive integers."""
+    try:
+        n = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"invalid int value: {value!r}")
+    if n <= 0:
+        raise argparse.ArgumentTypeError(f"must be positive, got {n}")
+    return n
+
+
 def main():
     parser = argparse.ArgumentParser(description="Claude Chic")
     parser.add_argument(
@@ -45,6 +56,13 @@ def main():
         "--yolo",
         action="store_true",
         help="Auto-approve all tool uses without prompting (use in sandboxed environments)",
+    )
+    parser.add_argument(
+        "--width",
+        "-w",
+        type=positive_int,
+        default=None,
+        help="Set terminal width for chat column",
     )
     parser.add_argument("prompt", nargs="*", help="Initial prompt to send")
     args = parser.parse_args()
@@ -86,6 +104,7 @@ def main():
             remote_port=args.remote_port,
             skip_permissions=args.dangerously_skip_permissions,
             theme_override=args.theme,
+            width=args.width,
         )
         app.run()
     except (KeyboardInterrupt, SystemExit):

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -862,13 +862,10 @@ class ChatApp(App):
         # Focus input immediately - UI is ready
         self.chat_input.focus()
 
-        # Apply --width CLI override
+        # Apply --width CLI override to chat column max-width
         if self._width is not None:
-            try:
-                chat_column = self.query_one("#chat-column")
+            if chat_column := self.query_one_optional("#chat-column"):
                 chat_column.styles.max_width = self._width
-            except Exception:
-                pass
 
         # Initialize vi mode if enabled in config
         if CONFIG.get("vi-mode"):

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -228,9 +228,11 @@ class ChatApp(App):
         remote_port: int = 0,
         skip_permissions: bool = False,
         theme_override: str | None = None,
+        width: int | None = None,
     ) -> None:
         super().__init__()
         self.scroll_sensitivity_y = 1.0  # Smoother scrolling (default is 2.0)
+        self._width = width
         # AgentManager is the single source of truth for agents
         self.agent_mgr: AgentManager | None = None
 
@@ -859,6 +861,14 @@ class ChatApp(App):
 
         # Focus input immediately - UI is ready
         self.chat_input.focus()
+
+        # Apply --width CLI override
+        if self._width is not None:
+            try:
+                chat_column = self.query_one("#chat-column")
+                chat_column.styles.max_width = self._width
+            except Exception:
+                pass
 
         # Initialize vi mode if enabled in config
         if CONFIG.get("vi-mode"):

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -34,6 +34,17 @@ async def test_app_mounts_basic_widgets(mock_sdk):
 
 
 @pytest.mark.asyncio
+async def test_width_cli_arg_applied(mock_sdk):
+    """--width sets max_width on the chat column."""
+    app = ChatApp(width=160)
+    async with app.run_test():
+        chat_column = app.query_one("#chat-column")
+        max_width = chat_column.styles.max_width
+        assert max_width is not None
+        assert max_width.value == 160
+
+
+@pytest.mark.asyncio
 async def test_permission_mode_cycle(mock_sdk):
     """Shift+Tab cycles permission mode: default -> acceptEdits -> plan -> auto -> default."""
     app = ChatApp()


### PR DESCRIPTION
## Why

Claudechic caps chat column width at 80 characters by default. This can be too narrow for some users or use cases, in particular code-heavy sessions where diffs and logs get clipped. `--width` lets you override that limit without changing the source.

## Summary
- Add `--width` / `-w` CLI argument (positive integer)
- Apply `max_width` style to `#chat-column` on mount
- `positive_int` argparse type with clear error messages

## Changes
- `claudechic/__main__.py` — add `--width` arg + `positive_int` validator (+18)
- `claudechic/app.py` — accept and apply width override (+11)