### PR TITLE
Pr/ansi safety

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -15,6 +15,7 @@ from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from claude_agent_sdk.types import HookEvent
     from claudechic.screens.chat import ChatScreen
+    from textual.notifications import SeverityLevel
     from textual.timer import Timer
 
 from textual.app import App
@@ -64,7 +65,7 @@ from claudechic.config import CONFIG, NEW_INSTALL, save as save_config
 from claudechic.enums import AgentStatus, PermissionChoice, ToolName
 from claudechic.mcp import set_app, create_chic_server
 from claudechic.file_index import FileIndex
-from claudechic.formatting import trim_model_name
+from claudechic.formatting import strip_ansi, trim_model_name
 from claudechic.history import append_to_history
 from claudechic.widgets import (
     ContextBar,
@@ -276,6 +277,24 @@ class ChatApp(App):
         # Track pending slash commands passed to Claude (for typo detection)
         # agent_id -> command name (e.g., "/cleanup")
         self._pending_slash_commands: dict[str, str] = {}
+
+    def notify(
+        self,
+        message: str,
+        *,
+        title: str = "",
+        severity: "SeverityLevel" = "information",
+        timeout: float | None = None,
+        markup: bool = False,
+    ) -> None:
+        """Override to default markup=False and strip ANSI from untrusted content."""
+        super().notify(
+            strip_ansi(message),
+            title=strip_ansi(title) if title else title,
+            severity=severity,
+            timeout=timeout,
+            markup=markup,
+        )
 
     def _fatal_error(self) -> None:
         """Override to use plain Python tracebacks instead of rich's fancy ones."""
@@ -693,7 +712,7 @@ class ChatApp(App):
 
     def _handle_sdk_stderr(self, message: str) -> None:
         """Handle SDK stderr output by showing in chat."""
-        message = message.strip()
+        message = strip_ansi(message).strip()
         if not message:
             return
         self._show_system_info(message, "warning", None)
@@ -1310,6 +1329,7 @@ class ChatApp(App):
         self, message: str, severity: str, agent_id: str | None
     ) -> None:
         """Show system info message in chat view (not stored in history)."""
+        message = strip_ansi(message)
         from claudechic.filters import should_filter_message
 
         if should_filter_message(message):

--- a/claudechic/formatting.py
+++ b/claudechic/formatting.py
@@ -18,6 +18,30 @@ DEFAULT_CONTEXT_WINDOW = 200_000
 MAX_HEADER_WIDTH = 70  # Max width for tool headers
 
 
+# --- ANSI escape stripping (ECMA-48 compliant) ---
+
+_ANSI_ESCAPE_RE = re.compile(
+    r"""
+      \x1b \[  [0-9:;?<=>!]* [ -/]* [@-~]     # 7-bit CSI (\x1b[...m)
+    | \x9b     [0-9:;?<=>!]* [ -/]* [@-~]     # 8-bit CSI (\x9b...m)
+    | \x1b []\x5dP^_]  (?:[^\x07\x1b\x9c]*) (?:\x07|\x1b\\|\x9c)?  # OSC/DCS/PM/APC
+    | \x1b [()*/+\-.]  .                       # Charset designation
+    | \x1b [ -/]* [@-~]                        # Other 2-char escapes
+    | [\x90\x98\x9d-\x9f] [^\x07\x1b\x9c\x80-\x9f]* (?:\x07|\x1b\\|\x9c)?  # 8-bit string sequences (DCS/SOS/OSC/PM/APC)
+    """,
+    re.VERBOSE,
+)
+
+_CONTROL_BYTE_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\x80-\x9f]")
+
+_TOOL_SEARCH_MAX_SIZE = 65_536
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences and residual control bytes from *text*."""
+    return _CONTROL_BYTE_RE.sub("", _ANSI_ESCAPE_RE.sub("", text))
+
+
 # Inter-agent message patterns
 # Matches ask_agent: [Question from agent 'X' - please respond...]
 _AGENT_QUESTION_RE = re.compile(
@@ -42,13 +66,15 @@ def extract_tool_search_names(content) -> list[str] | None:
     """
     items = content
     if isinstance(content, str):
+        if len(content) > _TOOL_SEARCH_MAX_SIZE:
+            return None
         if not content.strip().startswith("[{"):
             return None
         try:
             import ast
 
             items = ast.literal_eval(content)
-        except (ValueError, SyntaxError):
+        except (ValueError, SyntaxError, MemoryError, RecursionError):
             return None
     if not isinstance(items, list):
         return None

--- a/claudechic/widgets/content/message.py
+++ b/claudechic/widgets/content/message.py
@@ -239,7 +239,7 @@ class ChatAttachment(Button):
             else:
                 subprocess.run(["xdg-open", self._path], check=True)
         except Exception as e:
-            self.app.notify(f"Failed to open: {e}", severity="error")
+            self.app.notify(f"Failed to open: {e}", severity="error", markup=False)
 
 
 class ImageAttachments(Horizontal):

--- a/claudechic/widgets/content/tools.py
+++ b/claudechic/widgets/content/tools.py
@@ -18,6 +18,7 @@ from claude_agent_sdk import ToolUseBlock, ToolResultBlock
 
 from claudechic.enums import ToolName
 from claudechic.formatting import (
+    _TOOL_SEARCH_MAX_SIZE,
     extract_tool_search_names,
     format_tool_header,
     format_tool_input,
@@ -51,7 +52,7 @@ def _extract_text_content(content: str | list) -> str:
     if isinstance(content, str):
         # Handle stringified MCP list format (SDK sometimes returns str repr)
         if content.startswith("[{") and "'text':" in content:
-            if len(content) > 65_536:
+            if len(content) > _TOOL_SEARCH_MAX_SIZE:
                 return content
             import ast
 

--- a/claudechic/widgets/content/tools.py
+++ b/claudechic/widgets/content/tools.py
@@ -51,6 +51,8 @@ def _extract_text_content(content: str | list) -> str:
     if isinstance(content, str):
         # Handle stringified MCP list format (SDK sometimes returns str repr)
         if content.startswith("[{") and "'text':" in content:
+            if len(content) > 65_536:
+                return content
             import ast
 
             try:
@@ -62,7 +64,7 @@ def _extract_text_content(content: str | list) -> str:
                         if isinstance(item, dict)
                     ]
                     return "\n".join(texts)
-            except (ValueError, SyntaxError):
+            except (ValueError, SyntaxError, MemoryError, RecursionError):
                 pass
         return content
     return str(content)

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -867,3 +867,12 @@ async def test_stop_review_polling_unconditional(mock_sdk):
         fake_timer.stop.assert_called_once()
         assert app._review_poll_timer is None
         assert app._review_poll_agent_id is None
+
+
+@pytest.mark.asyncio
+async def test_notify_defaults_markup_false(mock_sdk):
+    """notify() should default markup=False and strip ANSI to prevent MarkupError."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.notify("\x1b[31m[ERROR]\x1b[0m Something failed")
+        await pilot.pause()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -76,3 +76,10 @@ class TestStripAnsi:
 
     def test_osc8_hyperlink(self):
         assert strip_ansi("\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\") == "link"
+
+
+def test_extract_tool_search_names_rejects_oversized_input():
+    """Inputs > 64KB should return None without attempting ast.literal_eval."""
+    from claudechic.formatting import extract_tool_search_names
+    huge = "[{" + "x" * 70_000 + "}]"
+    assert extract_tool_search_names(huge) is None

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from claudechic.formatting import trim_model_name
+from claudechic.formatting import strip_ansi, trim_model_name
 
 
 @pytest.mark.parametrize(
@@ -20,3 +20,59 @@ from claudechic.formatting import trim_model_name
 )
 def test_trim_model_name(raw, expected):
     assert trim_model_name(raw) == expected
+
+
+class TestStripAnsi:
+    def test_strips_sgr_reset(self):
+        assert strip_ansi("\x1b[0mhello") == "hello"
+
+    def test_strips_sgr_color(self):
+        assert strip_ansi("\x1b[31mred\x1b[0m") == "red"
+
+    def test_multiple_sgr_sequences(self):
+        assert strip_ansi("\x1b[1m\x1b[31mbold red\x1b[0m") == "bold red"
+
+    def test_cursor_movement(self):
+        assert strip_ansi("\x1b[2Jhello\x1b[H") == "hello"
+
+    def test_osc_terminal_title_bel(self):
+        assert strip_ansi("\x1b]0;My Title\x07text") == "text"
+
+    def test_osc_terminal_title_7bit_st(self):
+        assert strip_ansi("\x1b]0;Title\x1b\\text") == "text"
+
+    def test_dcs_sequence(self):
+        assert strip_ansi("\x1bPdata\x1b\\text") == "text"
+
+    def test_charset_designation(self):
+        assert strip_ansi("\x1b(Btext") == "text"
+
+    def test_c1_csi(self):
+        assert strip_ansi("\x9b31mred\x9b0m") == "red"
+
+    def test_clean_input_unchanged(self):
+        assert strip_ansi("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert strip_ansi("") == ""
+
+    def test_brackets_preserved(self):
+        assert strip_ansi("[INFO] message") == "[INFO] message"
+
+    def test_combined_ansi_and_brackets(self):
+        assert strip_ansi("\x1b[31m[ERROR]\x1b[0m msg") == "[ERROR] msg"
+
+    def test_remaining_c1_bytes_stripped(self):
+        assert strip_ansi("hello\x01world") == "helloworld"
+
+    def test_nel_byte_does_not_swallow_text(self):
+        assert strip_ansi("ok\x85abc") == "okabc"
+
+    def test_8bit_osc_with_payload(self):
+        assert strip_ansi("\x9dTitle\x9ctext") == "text"
+
+    def test_bracketed_paste_mode(self):
+        assert strip_ansi("\x1b[?2004hpasted\x1b[?2004l") == "pasted"
+
+    def test_osc8_hyperlink(self):
+        assert strip_ansi("\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\") == "link"


### PR DESCRIPTION
## Why

SDK stderr and tool results can contain raw ANSI escape sequences. When these reach Textual's `notify()` (which defaults to `markup=True`), they trigger `MarkupError` crashes or render garbled output. Separately, `ast.literal_eval` on unbounded tool content is a DoS vector — a 100MB string from a tool result would freeze the app. This PR sanitizes at the SDK boundary and adds size guards.

## Summary
- Add `strip_ansi()` with comprehensive ECMA-48 coverage (CSI, OSC, DCS, PM, APC, 8-bit C1, charset designation, residual control bytes)
- Override `ChatApp.notify()` to default `markup=False` and strip ANSI
- Strip ANSI at SDK boundary (`_handle_sdk_stderr`, `_show_system_info`)
- Add 64KB size guard on `ast.literal_eval` in tool content parsing
- Catch `MemoryError`/`RecursionError` in `ast.literal_eval` calls
- Add `markup=False` to ChatAttachment error notification

## Changes
- `claudechic/formatting.py` — `strip_ansi()`, `_TOOL_SEARCH_MAX_SIZE` constant, safety catches (+30)
- `claudechic/app.py` — notify override + strip at SDK boundaries (+21/−2)
- `claudechic/widgets/content/tools.py` — size guard + error catches (+5/−2)
- `claudechic/widgets/content/message.py` — `markup=False` on error notify (+1/−1)
- `tests/test_formatting.py` — 22 tests for `strip_ansi` + size guard test (+64)
- `tests/test_app_ui.py` — notify markup test (+9)