### PR TITLE
fix: worktree finish bugfix and security hardening

### DIFF
--- a/claudechic/features/worktree/git.py
+++ b/claudechic/features/worktree/git.py
@@ -1,5 +1,6 @@
 """Git worktree management for isolated feature work."""
 
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 from enum import Enum, auto
@@ -7,6 +8,35 @@ from pathlib import Path
 
 from claudechic.config import CONFIG
 from claudechic.errors import log
+
+
+def branch_exists(branch: str, cwd: Path | None = None) -> bool:
+    """Check if a local branch exists. Rejects tags, remote refs, and revspecs."""
+    fmt_check = subprocess.run(
+        ["git", "check-ref-format", "--allow-onelevel", branch],
+        capture_output=True, cwd=cwd,
+    )
+    if fmt_check.returncode != 0:
+        return False
+    result = subprocess.run(
+        ["git", "show-ref", "--verify", f"refs/heads/{branch}"],
+        capture_output=True, cwd=cwd,
+    )
+    return result.returncode == 0
+
+
+def get_local_branches(
+    cwd: Path | None = None, exclude: str | None = None, limit: int = 5
+) -> list[str]:
+    """List local branch names for error message suggestions."""
+    result = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/"],
+        capture_output=True, text=True, cwd=cwd,
+    )
+    if result.returncode != 0:
+        return []
+    branches = [b for b in result.stdout.strip().split("\n") if b and b != exclude]
+    return sorted(branches)[:limit]
 
 
 class FinishPhase(Enum):
@@ -365,6 +395,13 @@ def start_worktree(
 
     Returns (success, message, worktree_path).
     """
+    if base is not None:
+        base_stripped = base.strip()
+        if not base_stripped:
+            return False, "Invalid base branch: must not be empty", None
+        if base_stripped.startswith("-"):
+            return False, "Invalid base branch: must not start with '-'", None
+
     try:
         main_wt = get_main_worktree()
 
@@ -643,7 +680,7 @@ def discard_all_changes(worktree_dir: Path) -> tuple[bool, str]:
     """
     # Reset staged and unstaged changes
     result = subprocess.run(
-        ["git", "checkout", "."], cwd=worktree_dir, capture_output=True, text=True
+        ["git", "checkout", "HEAD", "--", "."], cwd=worktree_dir, capture_output=True, text=True
     )
     if result.returncode != 0:
         return False, f"checkout failed: {result.stderr.strip()}"
@@ -698,6 +735,11 @@ def fast_forward_merge(info: FinishInfo) -> tuple[bool, str]:
 
 def get_finish_prompt(info: FinishInfo) -> str:
     """Generate the prompt for Claude to rebase and merge a feature branch."""
+    branch = shlex.quote(info.branch_name)
+    base = shlex.quote(info.base_branch)
+    main_dir = shlex.quote(str(info.main_dir))
+    # NOTE: Descriptive lines use unquoted names for readability.
+    # Shell command lines use shlex-quoted versions.
     return f"""Rebase and merge this feature branch:
 
 Branch: {info.branch_name}
@@ -707,10 +749,10 @@ Main dir: {info.main_dir}
 
 Steps:
 1. Check for uncommitted changes in the worktree (fail if any)
-2. Rebase {info.branch_name} onto the LOCAL {info.base_branch} branch (do NOT fetch from remote):
-   git rebase {info.base_branch}
-3. In the main dir ({info.main_dir}), merge {info.branch_name}:
-   cd {info.main_dir} && git merge {info.branch_name}
+2. Rebase {branch} onto the LOCAL {base} branch (do NOT fetch from remote):
+   git rebase {base}
+3. In the main dir ({info.main_dir}), merge {branch}:
+   cd {main_dir} && git merge {branch}
 
 Do NOT remove the worktree or delete the branch - the app will handle cleanup.
 Do NOT interact with remotes (no fetch, no pull, no push)."""

--- a/tests/test_worktree_finish.py
+++ b/tests/test_worktree_finish.py
@@ -15,8 +15,10 @@ from unittest.mock import patch
 import pytest
 
 from claudechic.features.worktree.git import (
+    branch_exists,
     cleanup_worktrees,
     get_finish_info,
+    get_local_branches,
     get_parent_branch,
     has_uncommitted_changes,
     read_parent_branch,
@@ -254,3 +256,27 @@ def test_cleanup_handles_stale_worktree_path(patched_main, tmp_path):
     assert success, msg
     # Stale ref is gone.
     assert "feat-stale" not in _git(repo, "worktree", "list")
+
+
+class TestBranchExists:
+    def test_existing_branch_returns_true(self, repo):
+        assert branch_exists("main", cwd=repo) is True
+
+    def test_nonexistent_branch_returns_false(self, repo):
+        assert branch_exists("nonexistent-branch-xyz", cwd=repo) is False
+
+    def test_does_not_match_tags(self, repo):
+        subprocess.run(["git", "tag", "v1.0"], cwd=repo, check=True, capture_output=True)
+        assert branch_exists("v1.0", cwd=repo) is False
+
+    def test_rejects_revision_expressions(self, repo):
+        assert branch_exists("HEAD~1", cwd=repo) is False
+        assert branch_exists("main^", cwd=repo) is False
+
+
+@pytest.mark.usefixtures("patched_main")
+class TestStartWorktreeInjectionGuard:
+    def test_dash_prefix_returns_error(self, repo):
+        ok, msg, _ = start_worktree("test-feat", base="--evil", parent_cwd=repo)
+        assert not ok
+        assert "must not start with" in msg.lower() or "invalid" in msg.lower()


### PR DESCRIPTION
## Why

`/worktree finish` had a bug where staged changes survived `discard_all_changes()` (it ran `git checkout .` which only resets unstaged files). Additionally, the rebase prompt injected branch names directly into shell commands — a crafted branch name like `; rm -rf /` would execute arbitrary code. This PR fixes the discard bug and closes the injection vectors.

## Summary
- Fix `discard_all_changes()` to reset staged changes (`checkout HEAD -- .`)
- Add `branch_exists()` validation (rejects tags, remotes, revspecs)
- Add `get_local_branches()` for error message suggestions
- Add injection guard to `start_worktree()` (dash-prefix, empty base)
- Add `shlex.quote()` to `get_finish_prompt()` shell commands

## Changes
- `claudechic/features/worktree/git.py` — security fixes + new validators (+68/−5)
- `tests/test_worktree_finish.py` — tests for branch validation + injection guard (+26)