### PR TITLE
Pr/session id command

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -276,6 +276,10 @@ class ChatApp(App):
         # Track pending slash commands passed to Claude (for typo detection)
         # agent_id -> command name (e.g., "/cleanup")
         self._pending_slash_commands: dict[str, str] = {}
+        # Clipboard robustness
+        self._osc52_cached: bool | None = None
+        self._copy_timer: Timer | None = None
+        self._copy_failed_notified: bool = False
 
     def _fatal_error(self) -> None:
         """Override to use plain Python tracebacks instead of rich's fancy ones."""
@@ -1547,11 +1551,80 @@ class ChatApp(App):
         if chat_view:
             chat_view.clear()
 
+    def _safe_get_selected_text(self) -> str | None:
+        """Get selected text, returning None on stale selection coordinates."""
+        try:
+            return self.screen.get_selected_text()
+        except IndexError:
+            return None
+
+    def _osc52_likely_works(self) -> bool:
+        """Check whether OSC 52 clipboard can reach the terminal. Cached."""
+        if self._osc52_cached is not None:
+            return self._osc52_cached
+        import os
+        import subprocess
+
+        if not os.environ.get("TMUX"):
+            self._osc52_cached = True
+            return True
+        try:
+            result = subprocess.run(
+                ["tmux", "show", "-gv", "set-clipboard"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            self._osc52_cached = result.stdout.strip().lower() != "off"
+        except Exception:
+            self._osc52_cached = True
+        return self._osc52_cached
+
+    def _try_copy(self, text: str) -> bool:
+        """Copy text to clipboard, returning True if we believe it succeeded."""
+        import shutil
+        import subprocess
+
+        self.copy_to_clipboard(text)  # OSC 52 + upstream PRIMARY override
+        if not sys.platform.startswith("linux"):
+            return True
+        for cmd in (
+            ["xclip", "-selection", "clipboard"],
+            ["xsel", "--clipboard", "--input"],
+        ):
+            if shutil.which(cmd[0]):
+                try:
+                    proc = subprocess.Popen(
+                        cmd,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    proc.stdin.write(text.encode())  # type: ignore[union-attr]
+                    proc.stdin.close()  # type: ignore[union-attr]
+                    proc.wait(timeout=2)
+                    if proc.returncode == 0:
+                        return True
+                    continue  # non-zero exit (e.g., no DISPLAY), try next tool
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                    continue
+                except Exception:
+                    continue
+        return self._osc52_likely_works()
+
     def action_copy_selection(self) -> None:
-        selected = self.screen.get_selected_text()
+        selected = self._safe_get_selected_text()
         if selected:
-            self.copy_to_clipboard(selected)
-            self.notify("Copied to clipboard")
+            if self._try_copy(selected):
+                self._copy_failed_notified = False  # reset on success
+                self.notify("Copied to clipboard")
+            elif not self._copy_failed_notified:
+                self._copy_failed_notified = True
+                self.notify(
+                    "Copy failed — clipboard tool not found", severity="warning"
+                )
 
     def action_new_agent(self) -> None:
         """Create a new agent (prompts for name/path)."""
@@ -1635,10 +1708,20 @@ class ChatApp(App):
                 return
 
     def _check_and_copy_selection(self) -> None:
-        selected = self.screen.get_selected_text()
+        selected = self._safe_get_selected_text()
         if selected and len(selected.strip()) > 0:
-            self.copy_to_clipboard(selected)
-            self.notify("Copied", timeout=1)
+            if self._try_copy(selected):
+                self._copy_failed_notified = False  # reset on success
+                if self._copy_timer is not None:
+                    self._copy_timer.stop()
+                self._copy_timer = self.set_timer(
+                    0.5, lambda: self.notify("Copied", timeout=1)
+                )
+            elif not self._copy_failed_notified:
+                self._copy_failed_notified = True
+                self.notify(
+                    "Copy failed — clipboard tool not found", severity="warning"
+                )
 
     def action_quit(self) -> None:  # type: ignore[override]
         # If history search is visible, cancel it

--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -9,6 +9,7 @@ It's used by autocomplete (app.py) and help (help_data.py).
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import time
@@ -16,6 +17,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from claudechic.analytics import capture
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from claudechic.app import ChatApp
@@ -105,6 +108,7 @@ COMMANDS: list[tuple[str, str, list[str]]] = [
     ("/welcome", "Show welcome message", []),
     ("/reviewer", "Spawn a review agent for current changes", []),
     ("/rewind", "Rewind to a previous checkpoint", []),
+    ("/session-id", "Show and copy session ID", []),
     ("/help", "Show help", []),
     ("/exit", "Quit", []),
     ("!<cmd>", "Shell command alias", []),
@@ -248,6 +252,10 @@ def handle_command(app: "ChatApp", prompt: str) -> bool:
                 app._set_agent_effort(effort)
         return True
 
+    if cmd == "/session-id":
+        _track_command(app, "session-id")
+        return _handle_session_id(app)
+
     if cmd == "/exit":
         _track_command(app, "exit")
         app.exit()
@@ -379,6 +387,26 @@ SDK_PASSTHROUGH_COMMANDS = frozenset(
         "/ultrareview",  # Cloud-based parallel multi-agent review (Claude Code 2.1.111+)
     }
 )
+
+
+def _handle_session_id(app: "ChatApp") -> bool:
+    agent = app._agent
+    session_id = agent.session_id if agent else None
+    agent_id = agent.id if agent else None
+    if not session_id:
+        app._show_system_info("No active session", "info", agent_id)
+        return True
+    agent_name = agent.name if agent else "unknown"
+    msg = f"Session ID ({agent_name}): {session_id}"
+    app._show_system_info(msg, "info", agent_id)
+    try:
+        if app._try_copy(session_id):
+            app.notify("Session ID copied to clipboard")
+        else:
+            log.debug("Clipboard copy failed for session ID")
+    except Exception:
+        log.debug("Clipboard copy failed for session ID", exc_info=True)
+    return True
 
 
 def _handle_resume(app: "ChatApp", command: str) -> bool:

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -903,3 +903,27 @@ async def test_try_copy_returns_false_when_no_tools(mock_sdk):
              patch("sys.platform", "linux"):
             result = app._try_copy("test")
             assert result is False
+
+
+# =============================================================================
+# /session-id command (P6)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_session_id_command_shows_id(mock_sdk):
+    from claudechic.commands import handle_command
+
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        agent = app._agent
+        if not agent:
+            pytest.skip("No agent available")
+        agent.session_id = "abc-123-def"
+        with patch.object(app, "_show_system_info") as mock_info, \
+             patch.object(app, "_try_copy", return_value=True) as mock_copy:
+            handle_command(app, "/session-id")
+            mock_info.assert_called_once()
+            call_args = mock_info.call_args[0]
+            assert "abc-123-def" in call_args[0]
+            mock_copy.assert_called_once_with("abc-123-def")

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -1,6 +1,6 @@
 """App-level UI tests without SDK dependency."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -867,3 +867,39 @@ async def test_stop_review_polling_unconditional(mock_sdk):
         fake_timer.stop.assert_called_once()
         assert app._review_poll_timer is None
         assert app._review_poll_agent_id is None
+
+
+# =============================================================================
+# Clipboard robustness (P2)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_safe_get_selected_text_handles_index_error(mock_sdk):
+    """_safe_get_selected_text should return None on IndexError, not crash."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        with patch.object(app.screen, "get_selected_text", side_effect=IndexError("stale")):
+            result = app._safe_get_selected_text()
+            assert result is None
+
+
+@pytest.mark.asyncio
+async def test_try_copy_returns_bool(mock_sdk):
+    """_try_copy should return True on success."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        result = app._try_copy("test")
+        assert isinstance(result, bool)
+
+
+@pytest.mark.asyncio
+async def test_try_copy_returns_false_when_no_tools(mock_sdk):
+    """_try_copy should return False when no clipboard tools and OSC 52 off."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)):
+        with patch("shutil.which", return_value=None), \
+             patch.object(app, "_osc52_likely_works", return_value=False), \
+             patch("sys.platform", "linux"):
+            result = app._try_copy("test")
+            assert result is False


### PR DESCRIPTION
## Why

When debugging or sharing a session with someone, you need the session ID — but there was no way to get it without digging through `~/.claude/`. Now `/session-id` shows it in-chat and copies it to your clipboard in one step.

## Summary
- Add `/session-id` command that displays the current session ID and auto-copies it
- Uses `_try_copy()` from clipboard-robustness for reliable copy behavior
- Gracefully handles no-agent and no-session states

## Changes
- `claudechic/commands.py` — add `/session-id` handler + COMMANDS entry (+24)
- `claudechic/app.py` — clipboard robustness (from dependency on #1) (+95/−7)
- `tests/test_app_ui.py` — tests for `/session-id` + clipboard helpers (+61/−1)

**Depends on:** #1 (`pr/clipboard-robustness`) — uses `_try_copy()` for clipboard access