### PR TITLE
fix: include minutes in usage reset time display

### DIFF
--- a/claudechic/usage.py
+++ b/claudechic/usage.py
@@ -155,7 +155,10 @@ def format_reset_time(dt: datetime | None) -> str:
     # Format hour without leading zero (cross-platform)
     hour = local_dt.hour % 12 or 12
     ampm = "am" if local_dt.hour < 12 else "pm"
-    time_str = f"{hour}{ampm}"
+    if local_dt.minute:
+        time_str = f"{hour}:{local_dt.minute:02d}{ampm}"
+    else:
+        time_str = f"{hour}{ampm}"
 
     # If same day, just show time
     if local_dt.date() == now.date():


### PR DESCRIPTION
## Summary

- `format_reset_time` was formatting times as `3pm` / `11am` with no minutes, even when the reset doesn't fall on the hour
- Now shows `3:17pm` when minutes are non-zero; keeps `3pm` when they're zero (no change for on-the-hour resets)

One-line change in `claudechic/usage.py`.