### PR TITLE
sidebar: add ctrl-click and double-click actions on file items

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -1851,7 +1851,31 @@ class ChatApp(App):
         handle_command(self, f"/shell -i {editor} {event.plan_path}")
 
     def on_file_item_selected(self, event: FileItem.Selected) -> None:
-        """Handle file item click - open diff view focused on that file."""
+        """Handle file item click.
+
+        - plain click: diff vs HEAD (uncommitted changes)
+        - ctrl+click: diff this branch vs its base branch
+        - double-click: open the file in $EDITOR
+        """
+        if event.double_click:
+            editor = os.environ.get("EDITOR", "vi")
+            handle_command(self, f"/shell -i {editor} {event.file_path}")
+            return
+        if event.ctrl:
+            from claudechic.features.diff import get_base_branch
+
+            agent = self._agent
+            if not agent:
+                self.notify("No active agent", severity="error")
+                return
+            base = get_base_branch(str(agent.cwd))
+            if base:
+                self._toggle_diff_mode_for_file(
+                    str(event.file_path), target=f"{base}..."
+                )
+            else:
+                self.notify("Could not detect base branch", severity="warning")
+            return
         self._toggle_diff_mode_for_file(str(event.file_path))
 
     def on_hamburger_button_sidebar_toggled(
@@ -2896,8 +2920,8 @@ class ChatApp(App):
 
         self.push_screen(DiffScreen(agent.cwd, target or "HEAD"), on_dismiss)
 
-    def _toggle_diff_mode_for_file(self, file_path: str) -> None:
-        """Show diff screen focused on a specific file."""
+    def _toggle_diff_mode_for_file(self, file_path: str, target: str = "HEAD") -> None:
+        """Show diff screen focused on a specific file (default: vs HEAD)."""
         from claudechic.features.diff import HunkComment, format_hunk_comments
         from claudechic.screens import DiffScreen
 
@@ -2912,7 +2936,7 @@ class ChatApp(App):
             self.chat_input.focus()
 
         self.push_screen(
-            DiffScreen(agent.cwd, "HEAD", focus_file=file_path), on_dismiss
+            DiffScreen(agent.cwd, target, focus_file=file_path), on_dismiss
         )
 
     def _update_vi_mode(self, enabled: bool) -> None:

--- a/claudechic/features/diff/__init__.py
+++ b/claudechic/features/diff/__init__.py
@@ -6,6 +6,7 @@ from .git import (
     Hunk,
     HunkComment,
     format_hunk_comments,
+    get_base_branch,
     get_changes,
     get_file_stats,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "Hunk",
     "HunkComment",
     "format_hunk_comments",
+    "get_base_branch",
     "get_changes",
     "get_file_stats",
     "DiffSidebar",

--- a/claudechic/features/diff/git.py
+++ b/claudechic/features/diff/git.py
@@ -3,8 +3,49 @@
 import asyncio
 import difflib
 import re
+import subprocess
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
+
+
+@lru_cache(maxsize=16)
+def get_base_branch(cwd: str) -> str | None:
+    """Return the upstream default branch ref (e.g. 'origin/main') for branch-diff comparisons.
+
+    Tries `git symbolic-ref refs/remotes/origin/HEAD` first, then falls back to
+    common defaults. Returns None if nothing usable is found.
+
+    Cached per-cwd: base branch doesn't change at runtime; avoids re-spawning
+    git on every Ctrl+click. Restart the app if you re-init the repo.
+    """
+    try:
+        r = subprocess.run(
+            ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return r.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        pass
+
+    for ref in ("origin/main", "origin/master", "main", "master"):
+        try:
+            r = subprocess.run(
+                ["git", "rev-parse", "--verify", "--quiet", ref],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if r.returncode == 0:
+                return ref
+        except (subprocess.SubprocessError, OSError):
+            continue
+    return None
 
 
 @dataclass

--- a/claudechic/widgets/layout/sidebar.py
+++ b/claudechic/widgets/layout/sidebar.py
@@ -8,6 +8,7 @@ from textual.app import ComposeResult
 from textual.events import Click
 from textual.message import Message
 from textual.reactive import reactive
+from textual.timer import Timer
 from textual.widget import Widget
 from textual.widgets import Static, Label, ListItem
 from rich.text import Text
@@ -198,11 +199,28 @@ class FileItem(SidebarItem):
     """
 
     class Selected(Message):
-        """Posted when file is clicked."""
+        """Posted when file is clicked.
 
-        def __init__(self, file_path: Path) -> None:
+        - plain click: diff vs HEAD (uncommitted changes)
+        - ctrl+click: diff this branch vs its base branch
+        - double-click: open the file in $EDITOR
+        """
+
+        def __init__(
+            self,
+            file_path: Path,
+            *,
+            ctrl: bool = False,
+            double_click: bool = False,
+        ) -> None:
             self.file_path = file_path
+            self.ctrl = ctrl
+            self.double_click = double_click
             super().__init__()
+
+    # Wait this long after a single click before firing it, so a double-click
+    # can cancel and supersede. Trade-off: single-click diff has ~300ms lag.
+    DOUBLE_CLICK_INTERVAL = 0.3
 
     max_name_length: int = 14
 
@@ -218,6 +236,7 @@ class FileItem(SidebarItem):
         self.additions = additions
         self.deletions = deletions
         self.untracked = untracked
+        self._click_timer: Timer | None = None
 
     def _truncate_front(self, name: str) -> str:
         """Truncate from front with ellipsis if too long."""
@@ -238,8 +257,32 @@ class FileItem(SidebarItem):
             parts.append((f" -{self.deletions}", "dim red"))
         return Text.assemble(*parts)
 
-    def on_click(self, event) -> None:
-        self.post_message(self.Selected(self.file_path))
+    def on_click(self, event: Click) -> None:
+        # Double-click supersedes any pending single-click action.
+        if event.chain >= 2:
+            if self._click_timer is not None:
+                self._click_timer.stop()
+                self._click_timer = None
+            self.post_message(self.Selected(self.file_path, double_click=True))
+            return
+
+        # Single click: defer briefly so a second click can cancel and upgrade
+        # this into a double-click before the diff screen pushes.
+        if self._click_timer is not None:
+            self._click_timer.stop()
+        ctrl = event.ctrl
+
+        def fire_single() -> None:
+            self._click_timer = None
+            self.post_message(self.Selected(self.file_path, ctrl=ctrl))
+
+        self._click_timer = self.set_timer(self.DOUBLE_CLICK_INTERVAL, fire_single)
+
+    def on_unmount(self) -> None:
+        # Pending click timer would otherwise fire on a removed widget.
+        if self._click_timer is not None:
+            self._click_timer.stop()
+            self._click_timer = None
 
 
 class FilesSection(SidebarSection):


### PR DESCRIPTION
## Summary

Adds two new ways to interact with files in the right-sidebar Files panel, while keeping the existing default behavior intact:

- **click** — diff vs `HEAD` (uncommitted changes) — unchanged
- **ctrl+click** — diff this branch vs its base branch (committed changes on this branch)
- **double-click** — open the file in `$EDITOR`

### How it works

- `get_base_branch(cwd)` resolves the base ref via `git symbolic-ref refs/remotes/origin/HEAD`, falling back to `origin/main`, `origin/master`, `main`, `master`. Cached with `lru_cache(maxsize=16)` so repeated ctrl+clicks don't re-spawn git.
- `FileItem.on_click` defers single-click dispatch by 300ms so a follow-up click can upgrade the event to a double-click without first opening the diff screen. The timer is cancelled on `on_unmount` to avoid leaks if the sidebar refreshes mid-delay.
- `_toggle_diff_mode_for_file` gained an optional `target` parameter (default `"HEAD"`) so the ctrl+click path can pass `f"{base}..."`.

### Why these modifiers

Shift was avoided because terminals (Terminal.app, iTerm, Ghostty, ...) intercept Shift for text-selection and override the TUI cursor, which made the file row feel broken on hover. Ctrl + double-click work cleanly across the terminals I tested.

## Test plan

- [ ] Plain click on a file with uncommitted changes shows the HEAD diff
- [ ] Plain click on a file with no uncommitted changes shows "No uncommitted changes"
- [ ] Ctrl+click on a committed file shows the branch-vs-base diff
- [ ] Ctrl+click when no base branch can be resolved shows a "Could not detect base branch" warning
- [ ] Double-click opens the file in `\$EDITOR` (falls back to `vi`)
- [ ] Single-click followed by a second click within 300ms does NOT first flash the diff screen
- [ ] Hovering Ctrl over a file row keeps the pointer cursor (no Shift-style I-beam takeover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)